### PR TITLE
feat(gameplay): headshot ragdoll death system

### DIFF
--- a/Assets/Scripts/Gameplay/DeathEffect.cs
+++ b/Assets/Scripts/Gameplay/DeathEffect.cs
@@ -1,0 +1,106 @@
+using UnityEngine;
+
+namespace Plaga44.Gameplay
+{
+    /// <summary>
+    /// DeathEffect -- optional cosmetic layer on top of ragdoll death.
+    ///
+    /// Plays a particle system and/or a one-shot AudioClip at the moment of death.
+    /// Designed as a placeholder: swap out particleSystem / audioClip references
+    /// in the Inspector without changing code.
+    ///
+    /// Called automatically by MorsCerebri.Die() if this component is present.
+    /// Can also be called manually: deathEffect.Play(hitPoint, hitDirection).
+    /// </summary>
+    public class DeathEffect : MonoBehaviour
+    {
+        [Header("Particles")]
+        [Tooltip("Particle system to play at the hit point on death. Can be a prefab or scene instance.")]
+        [SerializeField] private ParticleSystem bloodParticle;
+
+        [Tooltip("If true, the particle system is spawned as an independent GameObject (won't " +
+                 "be disabled when this GO becomes inactive). Recommended for ragdolls.")]
+        [SerializeField] private bool spawnParticleIndependently = true;
+
+        [Header("Audio")]
+        [Tooltip("Sound played at death. Use a short impact/squelch SFX.")]
+        [SerializeField] private AudioClip deathSound;
+
+        [Tooltip("Volume for the death sound (0-1).")]
+        [Range(0f, 1f)]
+        [SerializeField] private float soundVolume = 1f;
+
+        [Tooltip("Pitch variation range +/- applied randomly to avoid repetition.")]
+        [Range(0f, 0.5f)]
+        [SerializeField] private float pitchVariation = 0.1f;
+
+        [Header("Debug")]
+        [Tooltip("Log a message when effect plays (useful during scene testing without assets).")]
+        [SerializeField] private bool logOnPlay = true;
+
+        /// <summary>
+        /// Triggers the death effect at the given world-space position.
+        /// Called by MorsCerebri after ragdoll activation.
+        /// </summary>
+        /// <param name="position">World-space hit point.</param>
+        /// <param name="direction">Impact direction (used to orient particle emission).</param>
+        public void Play(Vector3 position, Vector3 direction)
+        {
+            PlayParticle(position, direction);
+            PlaySound(position);
+
+            if (logOnPlay)
+                Debug.Log($"[DeathEffect] Effect played at {position} dir={direction} on {gameObject.name}");
+        }
+
+        // -----------------------------------------------------------------
+        // Private helpers
+        // -----------------------------------------------------------------
+
+        private void PlayParticle(Vector3 position, Vector3 direction)
+        {
+            if (bloodParticle == null) return;
+
+            Quaternion rotation = direction != Vector3.zero
+                ? Quaternion.LookRotation(direction)
+                : Quaternion.identity;
+
+            if (spawnParticleIndependently)
+            {
+                // Instantiate so the particle outlives the (possibly deactivated) enemy GO
+                ParticleSystem instance = Instantiate(bloodParticle, position, rotation);
+                instance.Play();
+
+                // Auto-destroy after particle finishes
+                float lifetime = instance.main.duration + instance.main.startLifetime.constantMax;
+                Destroy(instance.gameObject, lifetime + 0.5f);
+            }
+            else
+            {
+                bloodParticle.transform.SetPositionAndRotation(position, rotation);
+                bloodParticle.Play();
+            }
+        }
+
+        private void PlaySound(Vector3 position)
+        {
+            if (deathSound == null) return;
+
+            float pitch = 1f + Random.Range(-pitchVariation, pitchVariation);
+
+            // PlayClipAtPoint spawns a temporary AudioSource that survives GO deactivation
+            // We can't set pitch via PlayClipAtPoint, so we create a temporary source instead
+            GameObject tempGo = new GameObject("DeathSFX_Temp");
+            tempGo.transform.position = position;
+
+            AudioSource src = tempGo.AddComponent<AudioSource>();
+            src.clip        = deathSound;
+            src.volume      = soundVolume;
+            src.pitch       = pitch;
+            src.spatialBlend = 1f;  // full 3D
+            src.Play();
+
+            Destroy(tempGo, deathSound.length + 0.2f);
+        }
+    }
+}

--- a/Assets/Scripts/Gameplay/MorsCerebri.cs
+++ b/Assets/Scripts/Gameplay/MorsCerebri.cs
@@ -1,0 +1,110 @@
+using UnityEngine;
+using UnityEngine.Events;
+
+namespace Plaga44.Gameplay
+{
+    /// <summary>
+    /// Mors Cerebri -- "brain death". MonoBehaviour placed on a target (enemy root).
+    /// Listens for hit events from HitDetector. If HitZone == Head and
+    /// incoming force >= forceThreshold, triggers ragdoll death sequence.
+    ///
+    /// Wiring: HitDetector calls OnHit(HitData) on this component.
+    /// Requires: RagdollController on the same GameObject.
+    /// </summary>
+    [RequireComponent(typeof(RagdollController))]
+    public class MorsCerebri : MonoBehaviour
+    {
+        [Header("Death Config")]
+        [Tooltip("Minimum force required on a head hit to trigger brain death.")]
+        [SerializeField] private float forceThreshold = 10f;
+
+        [Header("Optional FX")]
+        [SerializeField] private DeathEffect deathEffect;
+
+        [Header("Events")]
+        public UnityEvent OnDeath;
+
+        private RagdollController _ragdoll;
+        private bool _isDead;
+
+        private void Awake()
+        {
+            _ragdoll = GetComponent<RagdollController>();
+
+            // Auto-wire DeathEffect if not assigned but present on same GO
+            if (deathEffect == null)
+                deathEffect = GetComponent<DeathEffect>();
+        }
+
+        /// <summary>
+        /// Called by HitDetector when any body part is hit.
+        /// </summary>
+        /// <param name="data">Hit information including zone, force and direction.</param>
+        public void OnHit(HitData data)
+        {
+            if (_isDead) return;
+            if (data.zone != HitZone.Head) return;
+            if (data.force < forceThreshold) return;
+
+            Die(data);
+        }
+
+        private void Die(HitData data)
+        {
+            _isDead = true;
+
+            _ragdoll.ActivateRagdoll(data.force, data.direction, data.hitPoint);
+
+            if (deathEffect != null)
+                deathEffect.Play(data.hitPoint, data.direction);
+
+            OnDeath?.Invoke();
+
+            Debug.Log($"[MorsCerebri] {gameObject.name} killed by headshot. Force={data.force:F1}");
+        }
+
+        /// <summary>Whether this target is already dead.</summary>
+        public bool IsDead => _isDead;
+    }
+
+    // -------------------------------------------------------------------------
+    // Shared data types used across Gameplay scripts
+    // -------------------------------------------------------------------------
+
+    /// <summary>Body zone identifier for hit detection routing.</summary>
+    public enum HitZone
+    {
+        None,
+        Head,
+        Torso,
+        LeftArm,
+        RightArm,
+        LeftLeg,
+        RightLeg
+    }
+
+    /// <summary>Data payload sent from HitDetector to damage receivers.</summary>
+    [System.Serializable]
+    public struct HitData
+    {
+        /// <summary>Which body zone was struck.</summary>
+        public HitZone zone;
+
+        /// <summary>Magnitude of impact force (kg*m/s or arbitrary game units).</summary>
+        public float force;
+
+        /// <summary>World-space direction of the incoming projectile/impact.</summary>
+        public Vector3 direction;
+
+        /// <summary>World-space point of impact.</summary>
+        public Vector3 hitPoint;
+
+        public HitData(HitZone zone, float force, Vector3 direction, Vector3 hitPoint)
+        {
+            this.zone      = zone;
+            this.force     = force;
+            this.direction = direction;
+            this.hitPoint  = hitPoint;
+        }
+    }
+}

--- a/Assets/Scripts/Gameplay/RagdollController.cs
+++ b/Assets/Scripts/Gameplay/RagdollController.cs
@@ -1,0 +1,150 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace Plaga44.Gameplay
+{
+    /// <summary>
+    /// RagdollController manages the physics-based death pose of a character.
+    ///
+    /// Setup (Inspector):
+    ///   1. Assign the character's Animator component.
+    ///   2. All bones that should ragdoll must have both a Rigidbody and a Collider.
+    ///      Use Unity's built-in Ragdoll Wizard (right-click hierarchy) to generate them.
+    ///   3. Optionally assign the specific bone that receives the impact force
+    ///      (e.g. head bone for headshots). If left empty, the root Rigidbody is used.
+    ///
+    /// On ActivateRagdoll():
+    ///   - Animator is disabled so animation stops driving transforms.
+    ///   - All child Rigidbodies are switched from kinematic to dynamic.
+    ///   - An impulse force is applied at the hit bone in the impact direction.
+    /// </summary>
+    public class RagdollController : MonoBehaviour
+    {
+        [Header("References")]
+        [Tooltip("The Animator controlling this character. Will be disabled on death.")]
+        [SerializeField] private Animator animator;
+
+        [Tooltip("Bone that receives the primary impact force (e.g. head bone Transform). " +
+                 "If null, the nearest Rigidbody on the root is used.")]
+        [SerializeField] private Transform impactBone;
+
+        [Header("Force Config")]
+        [Tooltip("Multiplier applied to the incoming hit force when calculating the ragdoll impulse.")]
+        [SerializeField] private float ragdollForceMultiplier = 15f;
+
+        [Tooltip("Minimum impact force (after multiplier) to apply as an impulse. " +
+                 "Prevents micro-forces from doing nothing meaningful.")]
+        [SerializeField] private float forceThreshold = 5f;
+
+        [Header("Collision Layers")]
+        [Tooltip("Layer mask for ragdoll bones to avoid self-collision issues.")]
+        [SerializeField] private LayerMask ragdollLayer;
+
+        // All Rigidbodies found under this GameObject at startup
+        private Rigidbody[] _bones;
+        private bool _ragdollActive;
+
+        private void Awake()
+        {
+            // Collect all rigidbodies (bones) in the hierarchy
+            _bones = GetComponentsInChildren<Rigidbody>(includeInactive: true);
+
+            // Auto-find Animator if not assigned
+            if (animator == null)
+                animator = GetComponentInChildren<Animator>();
+
+            // Start in animated mode (kinematic ragdoll bones)
+            SetRagdollState(false);
+        }
+
+        /// <summary>
+        /// Switches the character from animation-driven to physics-driven (ragdoll).
+        /// Called by MorsCerebri when a lethal headshot is detected.
+        /// </summary>
+        /// <param name="hitForce">Raw force magnitude from HitData.</param>
+        /// <param name="hitDirection">World-space direction of the projectile.</param>
+        /// <param name="hitPoint">World-space point of impact.</param>
+        public void ActivateRagdoll(float hitForce, Vector3 hitDirection, Vector3 hitPoint)
+        {
+            if (_ragdollActive) return;
+            _ragdollActive = true;
+
+            // 1. Stop the animator
+            if (animator != null)
+                animator.enabled = false;
+
+            // 2. Enable all ragdoll Rigidbodies
+            SetRagdollState(true);
+
+            // 3. Apply impulse to the impact bone (or root)
+            float impulse = hitForce * ragdollForceMultiplier;
+            if (impulse < forceThreshold) impulse = forceThreshold;
+
+            Rigidbody targetRb = FindImpactRigidbody(hitPoint);
+            if (targetRb != null)
+            {
+                targetRb.AddForceAtPosition(
+                    hitDirection.normalized * impulse,
+                    hitPoint,
+                    ForceMode.Impulse
+                );
+            }
+
+            Debug.Log($"[RagdollController] Ragdoll activated on {gameObject.name}. " +
+                      $"Impulse={impulse:F1} on bone={targetRb?.name ?? "none"}");
+        }
+
+        // -----------------------------------------------------------------
+        // Private helpers
+        // -----------------------------------------------------------------
+
+        /// <summary>
+        /// Enables or disables physics simulation on all ragdoll bones.
+        /// When kinematic=true the Animator drives transforms; when false physics takes over.
+        /// </summary>
+        private void SetRagdollState(bool physicsActive)
+        {
+            foreach (Rigidbody rb in _bones)
+            {
+                rb.isKinematic = !physicsActive;
+                rb.detectCollisions = physicsActive;
+            }
+        }
+
+        /// <summary>
+        /// Finds the best Rigidbody to receive the impact force.
+        /// Prefers the explicitly assigned impactBone; falls back to nearest bone
+        /// to the hit point; falls back to the first bone in the list.
+        /// </summary>
+        private Rigidbody FindImpactRigidbody(Vector3 hitPoint)
+        {
+            // Explicit assignment wins
+            if (impactBone != null)
+            {
+                var rb = impactBone.GetComponent<Rigidbody>();
+                if (rb != null) return rb;
+            }
+
+            // Nearest bone to hit point
+            if (_bones == null || _bones.Length == 0) return null;
+
+            Rigidbody nearest = null;
+            float minDist = float.MaxValue;
+
+            foreach (Rigidbody rb in _bones)
+            {
+                float dist = Vector3.SqrMagnitude(rb.position - hitPoint);
+                if (dist < minDist)
+                {
+                    minDist = dist;
+                    nearest = rb;
+                }
+            }
+
+            return nearest;
+        }
+
+        /// <summary>Whether the ragdoll is currently active.</summary>
+        public bool IsRagdollActive => _ragdollActive;
+    }
+}


### PR DESCRIPTION
Closes #21

## Summary

- **MorsCerebri** (`Assets/Scripts/Gameplay/MorsCerebri.cs`) -- MonoBehaviour placed on enemy root. Receives `HitData` via `OnHit()`, checks `HitZone == Head` and `force >= forceThreshold`, then fires `RagdollController.ActivateRagdoll()`. Exposes `UnityEvent OnDeath` for downstream hooks.
- **RagdollController** (`Assets/Scripts/Gameplay/RagdollController.cs`) -- Disables `Animator`, switches all child `Rigidbody` bones from kinematic to dynamic, applies impulse at nearest/assigned bone. Configurable: `forceThreshold`, `ragdollForceMultiplier`.
- **DeathEffect** (`Assets/Scripts/Gameplay/DeathEffect.cs`) -- Optional cosmetic layer: spawns `ParticleSystem` at hit point (independent GO so it outlives the enemy), plays 3D spatial `AudioClip` with pitch randomization. Pure placeholder -- swap assets in Inspector.
- Shared data types `HitData` (struct) and `HitZone` (enum) live in `MorsCerebri.cs` under `Plaga44.Gameplay` namespace.

No existing files were modified.

## Test plan

- [ ] Open Unity 6, let it compile. Expect 0 errors in Console.
- [ ] Create a test enemy: humanoid with Animator + Ragdoll Wizard bones (each bone has Rigidbody + Collider, all kinematic).
- [ ] Add `MorsCerebri` to the root. `RagdollController` is added automatically via `[RequireComponent]`. Optionally add `DeathEffect`.
- [ ] In Inspector set `forceThreshold = 5` on MorsCerebri, `ragdollForceMultiplier = 15` on RagdollController.
- [ ] In a test script call: `morsCerebri.OnHit(new HitData(HitZone.Head, 20f, Vector3.forward, headBone.position));`
- [ ] Expected result: Animator stops, enemy collapses into ragdoll, impulse sends the head bone forward. If DeathEffect is configured: particle plays + sound fires.
- [ ] Call `OnHit` with `HitZone.Torso` -- no ragdoll should trigger.
- [ ] Call `OnHit` with `HitZone.Head, force=2f` (below threshold) -- no ragdoll.
- [ ] Call `OnHit` twice after death -- no double-activation (guard flag `_isDead`).