### PR TITLE
feat: throwable stone with owner tracking and impact force

### DIFF
--- a/Assets/Editor/StoneFactory.cs
+++ b/Assets/Editor/StoneFactory.cs
@@ -1,0 +1,171 @@
+#if UNITY_EDITOR
+using UnityEditor;
+using UnityEngine;
+using Plaga44.Gameplay;
+
+namespace Plaga44.Editor
+{
+    /// <summary>
+    /// Editor utility: CYBERNOMAD / Scene Setup / Add Test Stones
+    ///
+    /// Creates three ThrowableStone GameObjects (small / medium / large) in the
+    /// active scene, each with:
+    ///   - SphereCollider (radius proportional to size)
+    ///   - Rigidbody (continuous collision detection)
+    ///   - ThrowableStone component
+    ///   - URP Lit grey material (roughness 0.85)
+    ///
+    /// Stones are placed at eye level (~1.4 m) in front of the origin,
+    /// spaced 0.4 m apart so they are immediately visible in the scene view.
+    /// </summary>
+    public static class StoneFactory
+    {
+        private const string LOG      = "[PLAGA44]";
+        private const string MENU     = "CYBERNOMAD/Scene Setup/Add Test Stones";
+        private const int    PRIORITY = 102;
+
+        // Stone definitions: (name, scale, mass in kg)
+        private static readonly (string name, float scale, float mass)[] StonePresets =
+        {
+            ("Stone_Small",  0.05f, 0.15f),
+            ("Stone_Medium", 0.10f, 0.40f),
+            ("Stone_Large",  0.18f, 1.00f),
+        };
+
+        [MenuItem(MENU, false, PRIORITY)]
+        public static void AddTestStones()
+        {
+            Debug.Log($"{LOG} === Add Test Stones ===");
+
+            // Parent container keeps the hierarchy clean
+            var parent = new GameObject("TestStones");
+            parent.transform.position = Vector3.zero;
+            Undo.RegisterCreatedObjectUndo(parent, "Create Test Stones Parent");
+
+            // Shared grey material (created once, reused across all stones)
+            Material stoneMat = CreateStoneMaterial();
+
+            float spacing = 0.40f;
+            float startX  = -(StonePresets.Length - 1) * spacing * 0.5f;
+
+            for (int i = 0; i < StonePresets.Length; i++)
+            {
+                var (stoneName, scale, mass) = StonePresets[i];
+
+                Vector3 pos = new Vector3(
+                    startX + i * spacing,
+                    1.40f,   // eye level (~1.4 m above origin)
+                    1.00f    // 1 m in front
+                );
+
+                GameObject stone = CreateStone(stoneName, pos, scale, mass, stoneMat, parent.transform);
+                Undo.RegisterCreatedObjectUndo(stone, $"Create {stoneName}");
+
+                Debug.Log($"{LOG} Created {stoneName}: scale={scale} mass={mass} kg at {pos}");
+            }
+
+            Selection.activeGameObject = parent;
+
+            UnityEditor.SceneManagement.EditorSceneManager.MarkSceneDirty(
+                UnityEditor.SceneManagement.EditorSceneManager.GetActiveScene());
+
+            Debug.Log($"{LOG} === Test Stones ready. Select TestStones in hierarchy. ===");
+        }
+
+        // ------------------------------------------------------------------ //
+        //  Private helpers
+        // ------------------------------------------------------------------ //
+
+        private static GameObject CreateStone(
+            string stoneName,
+            Vector3 worldPos,
+            float   scale,
+            float   mass,
+            Material mat,
+            Transform parent)
+        {
+            // Sphere primitive gives us MeshFilter + MeshRenderer + SphereCollider
+            var go = GameObject.CreatePrimitive(PrimitiveType.Sphere);
+            go.name = stoneName;
+            go.transform.SetParent(parent, worldPositionStays: false);
+            go.transform.position   = worldPos;
+            go.transform.localScale = Vector3.one * scale;
+
+            // Apply shared material
+            var renderer = go.GetComponent<Renderer>();
+            if (renderer != null)
+                renderer.sharedMaterial = mat;
+
+            // Rigidbody -- ThrowableStone.Awake() will also configure it,
+            // but we set sensible defaults here so the inspector shows them.
+            var rb = go.AddComponent<Rigidbody>();
+            rb.mass = mass;
+            rb.collisionDetectionMode = CollisionDetectionMode.Continuous;
+            rb.isKinematic = true; // ThrowableStone starts kinematic
+
+            // ThrowableStone -- use SerializedObject so the _mass field in the
+            // inspector reflects the preset value immediately.
+            var stone = go.AddComponent<ThrowableStone>();
+            var so    = new SerializedObject(stone);
+            var prop  = so.FindProperty("_mass");
+            if (prop != null)
+            {
+                prop.floatValue = mass;
+                so.ApplyModifiedProperties();
+            }
+
+            return go;
+        }
+
+        /// <summary>
+        /// Creates a URP Lit material with grey albedo and high roughness.
+        /// Saves it as an asset so it persists across domain reloads.
+        /// If the asset already exists it is reused.
+        /// </summary>
+        private static Material CreateStoneMaterial()
+        {
+            const string assetPath = "Assets/Materials/Stone_Grey.mat";
+
+            // Reuse existing asset if present
+            var existing = AssetDatabase.LoadAssetAtPath<Material>(assetPath);
+            if (existing != null)
+            {
+                Debug.Log($"{LOG} Reusing existing material: {assetPath}");
+                return existing;
+            }
+
+            Shader shader = Shader.Find("Universal Render Pipeline/Lit");
+            if (shader == null)
+            {
+                Debug.LogWarning($"{LOG} URP Lit shader not found -- falling back to Standard.");
+                shader = Shader.Find("Standard");
+            }
+
+            var mat = new Material(shader);
+            mat.name = "Stone_Grey";
+
+            // Albedo: mid-grey with a very slight warm tint (stone-like)
+            mat.color = new Color(0.45f, 0.43f, 0.40f, 1f);
+
+            // URP Lit property names
+            // Smoothness 0 = fully rough; Metallic 0 = non-metal
+            if (mat.HasProperty("_Smoothness"))
+                mat.SetFloat("_Smoothness", 0.15f);    // rough surface
+
+            if (mat.HasProperty("_Metallic"))
+                mat.SetFloat("_Metallic", 0.0f);
+
+            // Ensure Materials folder exists
+            if (!System.IO.Directory.Exists(Application.dataPath + "/Materials"))
+                System.IO.Directory.CreateDirectory(Application.dataPath + "/Materials");
+
+            AssetDatabase.CreateAsset(mat, assetPath);
+            AssetDatabase.SaveAssets();
+            AssetDatabase.Refresh();
+
+            Debug.Log($"{LOG} Created material: {assetPath}");
+            return mat;
+        }
+    }
+}
+#endif

--- a/Assets/Scripts/Gameplay/ThrowableStone.cs
+++ b/Assets/Scripts/Gameplay/ThrowableStone.cs
@@ -1,0 +1,219 @@
+using UnityEngine;
+
+namespace Plaga44.Gameplay
+{
+    /// <summary>
+    /// Throwable stone with owner tracking and impact force calculation.
+    ///
+    /// Lifecycle:
+    ///   OnGrab(thrower)  -- call this when a player/hand picks up the stone
+    ///   OnRelease()      -- call this when the stone is released (thrown)
+    ///   OnCollisionEnter -- calculates impact force = velocity * mass, raises OnImpact event
+    ///
+    /// Attach to any GameObject that has a Rigidbody and a Collider.
+    /// The Rigidbody is set to kinematic while the stone is held;
+    /// it switches to dynamic on release so physics drives the throw.
+    /// </summary>
+    [RequireComponent(typeof(Rigidbody))]
+    [RequireComponent(typeof(Collider))]
+    public class ThrowableStone : MonoBehaviour
+    {
+        // ------------------------------------------------------------------ //
+        //  Inspector
+        // ------------------------------------------------------------------ //
+
+        [Header("Physics")]
+        [Tooltip("Mass of the stone in kg. Affects impact force.")]
+        [SerializeField] private float _mass = 0.3f;
+
+        [Tooltip("Physics material applied to the collider (optional -- leave null for default).")]
+        [SerializeField] private PhysicsMaterial _physicsMaterial;
+
+        [Header("Debug")]
+        [Tooltip("Print grab / release / impact events to the Unity Console.")]
+        [SerializeField] private bool _debugLog = true;
+
+        // ------------------------------------------------------------------ //
+        //  Runtime state (public read, private write)
+        // ------------------------------------------------------------------ //
+
+        /// <summary>Transform that last grabbed this stone (null if never grabbed).</summary>
+        public Transform CurrentHolder  { get; private set; }
+
+        /// <summary>Transform that last threw this stone (null if never thrown).</summary>
+        public Transform LastThrownBy   { get; private set; }
+
+        /// <summary>True while the stone is held by someone.</summary>
+        public bool IsHeld              { get; private set; }
+
+        /// <summary>Velocity at the moment of release, in world space.</summary>
+        public Vector3 ReleaseVelocity  { get; private set; }
+
+        // ------------------------------------------------------------------ //
+        //  Events
+        // ------------------------------------------------------------------ //
+
+        /// <summary>
+        /// Raised on the first physics frame the stone hits something after being thrown.
+        /// Parameters: (stone, collision, impactForce).
+        /// impactForce = |velocity| * mass at point of contact.
+        /// </summary>
+        public event System.Action<ThrowableStone, Collision, float> OnImpact;
+
+        // ------------------------------------------------------------------ //
+        //  Private
+        // ------------------------------------------------------------------ //
+
+        private Rigidbody  _rb;
+        private Collider   _col;
+        private bool       _impactFiredSinceRelease;
+
+        private const string LOG = "[ThrowableStone]";
+
+        // ------------------------------------------------------------------ //
+        //  Unity lifecycle
+        // ------------------------------------------------------------------ //
+
+        private void Awake()
+        {
+            _rb  = GetComponent<Rigidbody>();
+            _col = GetComponent<Collider>();
+
+            _rb.mass = _mass;
+            _rb.collisionDetectionMode = CollisionDetectionMode.Continuous;
+
+            if (_physicsMaterial != null)
+                _col.material = _physicsMaterial;
+
+            // Start kinematic -- player must explicitly grab
+            SetKinematic(true);
+        }
+
+        private void OnCollisionEnter(Collision collision)
+        {
+            // Only fire impact once per throw, and only after the stone has been released
+            if (IsHeld || _impactFiredSinceRelease) return;
+
+            _impactFiredSinceRelease = true;
+
+            // Force = magnitude of momentum at impact: |v| * m
+            float impactForce = collision.relativeVelocity.magnitude * _rb.mass;
+
+            if (_debugLog)
+            {
+                Debug.Log(
+                    $"{LOG} '{name}' hit '{collision.gameObject.name}' " +
+                    $"| force={impactForce:F2} N " +
+                    $"| thrownBy={LastThrownBy?.name ?? "unknown"}");
+            }
+
+            OnImpact?.Invoke(this, collision, impactForce);
+        }
+
+        // ------------------------------------------------------------------ //
+        //  Public API
+        // ------------------------------------------------------------------ //
+
+        /// <summary>
+        /// Call when a hand / player grabs this stone.
+        /// The stone becomes kinematic so it can be parented/moved by the holder.
+        /// </summary>
+        /// <param name="holder">The Transform of the hand or player grabbing the stone.</param>
+        public void OnGrab(Transform holder)
+        {
+            if (holder == null)
+            {
+                Debug.LogWarning($"{LOG} OnGrab called with null holder on '{name}'.");
+                return;
+            }
+
+            CurrentHolder = holder;
+            IsHeld        = true;
+            _impactFiredSinceRelease = false;
+
+            SetKinematic(true);
+
+            if (_debugLog)
+                Debug.Log($"{LOG} '{name}' grabbed by '{holder.name}'");
+        }
+
+        /// <summary>
+        /// Call when the stone is released (thrown).
+        /// The stone becomes dynamic and inherits the provided velocity.
+        /// </summary>
+        /// <param name="releaseVelocity">
+        /// Velocity to apply to the Rigidbody at release, in world space.
+        /// Pass Vector3.zero if the hand was stationary.
+        /// </param>
+        public void OnRelease(Vector3 releaseVelocity)
+        {
+            if (!IsHeld)
+            {
+                Debug.LogWarning($"{LOG} OnRelease called on '{name}' but stone is not held.");
+                return;
+            }
+
+            LastThrownBy     = CurrentHolder;
+            CurrentHolder    = null;
+            IsHeld           = false;
+            ReleaseVelocity  = releaseVelocity;
+            _impactFiredSinceRelease = false;
+
+            SetKinematic(false);
+
+            _rb.linearVelocity = releaseVelocity;
+
+            if (_debugLog)
+            {
+                Debug.Log(
+                    $"{LOG} '{name}' released by '{LastThrownBy?.name ?? "unknown"}' " +
+                    $"| v={releaseVelocity.magnitude:F2} m/s " +
+                    $"| expectedForce={releaseVelocity.magnitude * _rb.mass:F2} N");
+            }
+        }
+
+        /// <summary>
+        /// Convenience overload: release with zero velocity (drop in place).
+        /// </summary>
+        public void OnRelease() => OnRelease(Vector3.zero);
+
+        /// <summary>
+        /// Current impact force estimate based on present Rigidbody velocity.
+        /// Useful for HUD / game logic before the stone actually hits anything.
+        /// </summary>
+        public float EstimatedImpactForce()
+            => _rb.linearVelocity.magnitude * _rb.mass;
+
+        // ------------------------------------------------------------------ //
+        //  Helpers
+        // ------------------------------------------------------------------ //
+
+        private void SetKinematic(bool kinematic)
+        {
+            _rb.isKinematic = kinematic;
+
+            if (kinematic)
+            {
+                _rb.linearVelocity        = Vector3.zero;
+                _rb.angularVelocity = Vector3.zero;
+            }
+        }
+
+        // ------------------------------------------------------------------ //
+        //  Editor helpers
+        // ------------------------------------------------------------------ //
+
+#if UNITY_EDITOR
+        private void OnValidate()
+        {
+            // Keep mass in sync with Rigidbody so the Inspector shows
+            // consistent values even before play mode.
+            if (_rb == null)
+                _rb = GetComponent<Rigidbody>();
+
+            if (_rb != null)
+                _rb.mass = _mass;
+        }
+#endif
+    }
+}


### PR DESCRIPTION
Closes #19

## Summary

- **`ThrowableStone.cs`** (`Assets/Scripts/Gameplay/`, namespace `Plaga44.Gameplay`) -- MonoBehaviour that manages the full grab/throw lifecycle
- **`StoneFactory.cs`** (`Assets/Editor/`, namespace `Plaga44.Editor`) -- editor menu tool that spawns 3 test stones and creates the URP material

## What was implemented

### ThrowableStone.cs

- `[RequireComponent(Rigidbody, Collider)]` -- enforced via attributes
- Configurable `_mass` field (Inspector: Physics section); synced to `Rigidbody.mass` on Awake and OnValidate
- Kinematic while held, dynamic on release -- prevents physics fighting while parented to a hand
- `OnGrab(Transform holder)` -- records `CurrentHolder`, sets kinematic
- `OnRelease(Vector3 releaseVelocity)` -- records `LastThrownBy`, applies velocity, goes dynamic
- `OnCollisionEnter` -- fires `OnImpact(stone, collision, force)` event once per throw; `force = relativeVelocity.magnitude * mass`
- `EstimatedImpactForce()` helper for HUD/game logic
- Unity 6 API: `linearVelocity`, `PhysicsMaterial`

### StoneFactory.cs

- Menu: CYBERNOMAD / Scene Setup / Add Test Stones (priority 102)
- Creates `TestStones` parent GameObject
- 3 stones at eye level (Y=1.4m), 1m in front, 0.4m apart:
  - Stone_Small: scale 0.05, mass 0.15 kg
  - Stone_Medium: scale 0.10, mass 0.40 kg
  - Stone_Large: scale 0.18, mass 1.00 kg
- Creates Assets/Materials/Stone_Grey.mat (URP Lit, grey, smoothness 0.15, metallic 0) on first run
- All operations wrapped in Undo; marks scene dirty

## Test plan

1. Open Unity 6 project (Android build target)
2. Open any scene
3. Run CYBERNOMAD > Scene Setup > Add Test Stones
4. Expected: TestStones parent with 3 sphere children appears in Hierarchy at Y=1.4, Z=1.0
5. Expected: Console shows 3 [PLAGA44] Created Stone_* lines
6. Expected: Assets/Materials/Stone_Grey.mat asset created (grey, rough)
7. Select Stone_Medium in Hierarchy, inspect ThrowableStone component -- mass should be 0.40
8. In Play Mode, call from any script:
   stone.OnGrab(someTransform);
   stone.OnRelease(new Vector3(0, 2, 5));
   -- wait for collision: Console should print hit + force + thrownBy
9. Verify stone.LastThrownBy is the Transform passed to OnGrab