### PR TITLE
feat: haptic feedback system for grab, release, impact, heartbeat, warning (#37)

### DIFF
--- a/Assets/Scripts/Feedback/HapticManager.cs
+++ b/Assets/Scripts/Feedback/HapticManager.cs
@@ -1,0 +1,227 @@
+// HapticManager.cs
+// PLAGA '44 -- Singleton manager for controller haptic feedback.
+// Wraps OVRInput.SetControllerVibration with per-event-type configurable
+// amplitude, frequency, and duration. All public fields are tweakable
+// at runtime via the Inspector (attach to any persistent GameObject).
+//
+// Guard: #if HAS_META_XR. Without Meta XR SDK the methods fall back to
+// Debug.Log so the rest of the codebase compiles and runs in the Editor.
+
+using System.Collections;
+using UnityEngine;
+
+namespace Plaga44.Feedback
+{
+    /// <summary>
+    /// Configurable parameters for a single haptic event.
+    /// </summary>
+    [System.Serializable]
+    public class HapticEvent
+    {
+        [Range(0f, 1f)] public float amplitude = 0.5f;
+        [Range(0f, 1f)] public float frequency = 0.5f;
+        [Min(0f)]       public float duration  = 0.1f;
+    }
+
+    /// <summary>
+    /// Singleton haptic manager. Place one instance in the scene on a
+    /// persistent GameObject (e.g. the OVRCameraRig). Survives scene loads
+    /// via DontDestroyOnLoad.
+    /// </summary>
+    public class HapticManager : MonoBehaviour
+    {
+        // --- Singleton -----------------------------------------------------------
+
+        private static HapticManager _instance;
+
+        public static HapticManager Instance
+        {
+            get
+            {
+                if (_instance == null)
+                    _instance = FindFirstObjectByType<HapticManager>();
+                return _instance;
+            }
+        }
+
+        // --- Per-event configuration (Inspector-tweakable) -----------------------
+
+        [Header("Grab / Release")]
+        public HapticEvent grab    = new HapticEvent { amplitude = 0.6f, frequency = 0.5f, duration = 0.12f };
+        public HapticEvent release = new HapticEvent { amplitude = 0.3f, frequency = 0.3f, duration = 0.08f };
+
+        [Header("Impact")]
+        public HapticEvent impactLight  = new HapticEvent { amplitude = 0.2f, frequency = 0.4f, duration = 0.06f };
+        public HapticEvent impactMedium = new HapticEvent { amplitude = 0.55f, frequency = 0.5f, duration = 0.12f };
+        public HapticEvent impactHeavy  = new HapticEvent { amplitude = 1.0f, frequency = 0.8f, duration = 0.22f };
+
+        [Tooltip("Force threshold (N) for medium impact. Below = light, above = heavy.")]
+        public float impactMediumThreshold = 5f;
+        [Tooltip("Force threshold (N) for heavy impact.")]
+        public float impactHeavyThreshold  = 15f;
+
+        [Header("Heartbeat")]
+        public HapticEvent heartbeatPulse = new HapticEvent { amplitude = 0.45f, frequency = 0.2f, duration = 0.08f };
+        [Tooltip("Pause (seconds) between the two pulses of a heartbeat lub-dub.")]
+        public float heartbeatInnerGap  = 0.12f;
+        [Tooltip("Pause (seconds) after a full lub-dub before the next one.")]
+        public float heartbeatOuterGap  = 0.55f;
+        [Tooltip("How many lub-dub cycles to play per PlayHeartbeat call. 0 = loop until StopHeartbeat.")]
+        public int   heartbeatCycles    = 3;
+
+        [Header("Warning")]
+        public HapticEvent warning = new HapticEvent { amplitude = 0.8f, frequency = 0.7f, duration = 0.15f };
+        [Tooltip("Number of warning pulses.")]
+        public int   warningPulses    = 3;
+        [Tooltip("Gap (seconds) between warning pulses.")]
+        public float warningPulseGap  = 0.18f;
+
+        // --- Unity lifecycle -----------------------------------------------------
+
+        private void Awake()
+        {
+            if (_instance != null && _instance != this)
+            {
+                Destroy(gameObject);
+                return;
+            }
+            _instance = this;
+            DontDestroyOnLoad(gameObject);
+        }
+
+        // --- Public API ----------------------------------------------------------
+
+        /// <summary>Play grab feedback on the given controller.</summary>
+        public void PlayGrab(OVRInput.Controller controller)
+        {
+            PlayOnce(controller, grab);
+        }
+
+        /// <summary>Play release feedback on the given controller.</summary>
+        public void PlayRelease(OVRInput.Controller controller)
+        {
+            PlayOnce(controller, release);
+        }
+
+        /// <summary>
+        /// Play impact feedback scaled by force magnitude.
+        /// Selects light / medium / heavy event based on configured thresholds.
+        /// </summary>
+        public void PlayImpact(OVRInput.Controller controller, float force)
+        {
+            HapticEvent evt;
+            if (force >= impactHeavyThreshold)
+                evt = impactHeavy;
+            else if (force >= impactMediumThreshold)
+                evt = impactMedium;
+            else
+                evt = impactLight;
+
+            // Scale amplitude proportionally within the chosen tier so small
+            // forces still feel graduated.
+            float scaledAmplitude = evt.amplitude;
+            if (force < impactMediumThreshold)
+            {
+                // light tier: scale 0..1 across [0, mediumThreshold)
+                scaledAmplitude = Mathf.Lerp(0.05f, impactLight.amplitude,
+                    Mathf.Clamp01(force / Mathf.Max(impactMediumThreshold, 0.001f)));
+            }
+            else if (force < impactHeavyThreshold)
+            {
+                // medium tier: scale across [mediumThreshold, heavyThreshold)
+                float t = Mathf.Clamp01((force - impactMediumThreshold) /
+                    Mathf.Max(impactHeavyThreshold - impactMediumThreshold, 0.001f));
+                scaledAmplitude = Mathf.Lerp(impactMedium.amplitude * 0.7f, impactMedium.amplitude, t);
+            }
+
+            HapticEvent scaled = new HapticEvent
+            {
+                amplitude = Mathf.Clamp01(scaledAmplitude),
+                frequency = evt.frequency,
+                duration  = evt.duration
+            };
+
+            PlayOnce(controller, scaled);
+        }
+
+        /// <summary>
+        /// Play a heartbeat pattern (lub-dub) for the configured number of cycles.
+        /// </summary>
+        public void PlayHeartbeat(OVRInput.Controller controller)
+        {
+            StartCoroutine(HeartbeatCoroutine(controller));
+        }
+
+        /// <summary>
+        /// Play repeating warning pulses.
+        /// </summary>
+        public void PlayWarning(OVRInput.Controller controller)
+        {
+            StartCoroutine(WarningCoroutine(controller));
+        }
+
+        // --- Internal helpers ----------------------------------------------------
+
+        private void PlayOnce(OVRInput.Controller controller, HapticEvent evt)
+        {
+#if HAS_META_XR
+            StartCoroutine(VibrationCoroutine(controller, evt.amplitude, evt.frequency, evt.duration));
+#else
+            Debug.Log($"[HapticManager] PlayOnce | ctrl={controller} amp={evt.amplitude:F2} freq={evt.frequency:F2} dur={evt.duration:F2}s");
+#endif
+        }
+
+#if HAS_META_XR
+        private IEnumerator VibrationCoroutine(OVRInput.Controller controller, float amplitude, float frequency, float duration)
+        {
+            OVRInput.SetControllerVibration(frequency, amplitude, controller);
+            yield return new WaitForSeconds(duration);
+            OVRInput.SetControllerVibration(0f, 0f, controller);
+        }
+#endif
+
+        private IEnumerator HeartbeatCoroutine(OVRInput.Controller controller)
+        {
+            int cycles = heartbeatCycles <= 0 ? int.MaxValue : heartbeatCycles;
+            for (int i = 0; i < cycles; i++)
+            {
+                // Lub
+#if HAS_META_XR
+                yield return StartCoroutine(VibrationCoroutine(controller,
+                    heartbeatPulse.amplitude, heartbeatPulse.frequency, heartbeatPulse.duration));
+#else
+                Debug.Log($"[HapticManager] Heartbeat LUB | ctrl={controller}");
+                yield return new WaitForSeconds(heartbeatPulse.duration);
+#endif
+                yield return new WaitForSeconds(heartbeatInnerGap);
+
+                // Dub (slightly softer)
+#if HAS_META_XR
+                yield return StartCoroutine(VibrationCoroutine(controller,
+                    heartbeatPulse.amplitude * 0.75f, heartbeatPulse.frequency, heartbeatPulse.duration));
+#else
+                Debug.Log($"[HapticManager] Heartbeat DUB | ctrl={controller}");
+                yield return new WaitForSeconds(heartbeatPulse.duration);
+#endif
+                if (i < cycles - 1)
+                    yield return new WaitForSeconds(heartbeatOuterGap);
+            }
+        }
+
+        private IEnumerator WarningCoroutine(OVRInput.Controller controller)
+        {
+            for (int i = 0; i < warningPulses; i++)
+            {
+#if HAS_META_XR
+                yield return StartCoroutine(VibrationCoroutine(controller,
+                    warning.amplitude, warning.frequency, warning.duration));
+#else
+                Debug.Log($"[HapticManager] Warning pulse {i + 1}/{warningPulses} | ctrl={controller}");
+                yield return new WaitForSeconds(warning.duration);
+#endif
+                if (i < warningPulses - 1)
+                    yield return new WaitForSeconds(warningPulseGap);
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Feedback/HapticOnGrab.cs
+++ b/Assets/Scripts/Feedback/HapticOnGrab.cs
@@ -1,0 +1,121 @@
+// HapticOnGrab.cs
+// PLAGA '44 -- MonoBehaviour that triggers haptic feedback when this
+// GameObject is grabbed or released. Attach to any grabbable object.
+//
+// Integration points:
+//   - Call OnGrab(controller)   from your grab system (e.g. OVRGrabbable, ISDK HandGrabInteractable)
+//   - Call OnRelease(controller) when the object leaves the hand
+//
+// Mass influence: heavier objects produce stronger grab feedback.
+// The mass curve is configurable via massAmplitudeMultiplierCurve in the Inspector.
+//
+// Guard: #if HAS_META_XR. Without the SDK the methods log to console.
+
+using UnityEngine;
+
+namespace Plaga44.Feedback
+{
+    [RequireComponent(typeof(Rigidbody))]
+    public class HapticOnGrab : MonoBehaviour
+    {
+        [Header("Mass Influence")]
+        [Tooltip("Multiplier applied to grab amplitude based on object mass (kg). " +
+                 "X axis = mass, Y axis = amplitude multiplier (0..2 range).")]
+        public AnimationCurve massAmplitudeMultiplierCurve = DefaultMassCurve();
+
+        [Tooltip("If true, the Rigidbody mass is used. If false, use overrideMass.")]
+        public bool useMass = true;
+
+        [Tooltip("Manual mass value when useMass = false.")]
+        [Min(0f)]
+        public float overrideMass = 1f;
+
+        // -------------------------------------------------------------------------
+
+        private Rigidbody _rb;
+
+        private void Awake()
+        {
+            _rb = GetComponent<Rigidbody>();
+        }
+
+        // --- Public API (call from grab system) ----------------------------------
+
+        /// <summary>
+        /// Call this when the object is grabbed.
+        /// </summary>
+        /// <param name="controller">The controller that performed the grab.</param>
+        public void OnGrab(OVRInput.Controller controller)
+        {
+            float multiplier = GetMassMultiplier();
+
+#if HAS_META_XR
+            if (HapticManager.Instance == null)
+            {
+                Debug.LogWarning("[HapticOnGrab] HapticManager not found in scene.");
+                return;
+            }
+
+            // Temporarily scale grab event amplitude by mass multiplier.
+            // We do this by cloning the event values locally and calling
+            // a helper that accepts explicit parameters.
+            var mgr = HapticManager.Instance;
+            float scaledAmp = Mathf.Clamp01(mgr.grab.amplitude * multiplier);
+            StartCoroutine(OneShot(controller, scaledAmp, mgr.grab.frequency, mgr.grab.duration));
+#else
+            Debug.Log($"[HapticOnGrab] OnGrab | ctrl={controller} massMultiplier={multiplier:F2}");
+#endif
+        }
+
+        /// <summary>
+        /// Call this when the object is released.
+        /// </summary>
+        /// <param name="controller">The controller that released the object.</param>
+        public void OnRelease(OVRInput.Controller controller)
+        {
+#if HAS_META_XR
+            if (HapticManager.Instance == null)
+            {
+                Debug.LogWarning("[HapticOnGrab] HapticManager not found in scene.");
+                return;
+            }
+            HapticManager.Instance.PlayRelease(controller);
+#else
+            Debug.Log($"[HapticOnGrab] OnRelease | ctrl={controller}");
+#endif
+        }
+
+        // --- Internal ------------------------------------------------------------
+
+        private float GetMassMultiplier()
+        {
+            float mass = useMass ? (_rb != null ? _rb.mass : overrideMass) : overrideMass;
+            return massAmplitudeMultiplierCurve.Evaluate(mass);
+        }
+
+#if HAS_META_XR
+        private System.Collections.IEnumerator OneShot(
+            OVRInput.Controller controller, float amplitude, float frequency, float duration)
+        {
+            OVRInput.SetControllerVibration(frequency, amplitude, controller);
+            yield return new WaitForSeconds(duration);
+            OVRInput.SetControllerVibration(0f, 0f, controller);
+        }
+#endif
+
+        // --- Default curve -------------------------------------------------------
+
+        /// <summary>
+        /// Default curve: mass 0 kg -> multiplier 0.4, mass 1 kg -> 1.0, mass 5+ kg -> 1.6.
+        /// </summary>
+        private static AnimationCurve DefaultMassCurve()
+        {
+            return new AnimationCurve(
+                new Keyframe(0f,  0.4f),
+                new Keyframe(1f,  1.0f),
+                new Keyframe(5f,  1.5f),
+                new Keyframe(20f, 2.0f)
+            );
+        }
+    }
+}

--- a/Assets/Scripts/Feedback/HapticOnImpact.cs
+++ b/Assets/Scripts/Feedback/HapticOnImpact.cs
@@ -1,0 +1,112 @@
+// HapticOnImpact.cs
+// PLAGA '44 -- MonoBehaviour that triggers haptic feedback on collision.
+// Attach to any physics object that should "feel" when it hits something.
+//
+// On OnCollisionEnter: measures impulse magnitude (approximation of force),
+// applies a minimum threshold to suppress micro-collisions, then calls
+// HapticManager.PlayImpact on the tracked controller.
+//
+// The controller to vibrate is set via SetActiveController() -- call this
+// from your grab system when the player picks up the object, and clear it
+// when released so impacts from non-held objects don't produce feedback.
+//
+// Guard: #if HAS_META_XR. Without the SDK the methods log to console.
+
+using UnityEngine;
+
+namespace Plaga44.Feedback
+{
+    public class HapticOnImpact : MonoBehaviour
+    {
+        [Header("Thresholds")]
+        [Tooltip("Minimum collision impulse magnitude (N*s) needed to trigger any feedback. " +
+                 "Filters out resting contacts and micro-jitter.")]
+        [Min(0f)]
+        public float minimumImpulse = 0.5f;
+
+        [Tooltip("Maximum impulse to clamp force passed to HapticManager.PlayImpact. " +
+                 "Prevents absurdly large values from breaking anything.")]
+        [Min(0f)]
+        public float maxImpulse = 50f;
+
+        [Header("Cooldown")]
+        [Tooltip("Minimum time (seconds) between consecutive impact haptics. " +
+                 "Prevents feedback spam when rolling on a surface.")]
+        [Min(0f)]
+        public float cooldown = 0.08f;
+
+        [Header("Layer Filter")]
+        [Tooltip("If set, only collisions with objects on these layers trigger feedback.")]
+        public LayerMask collisionLayers = ~0; // default: all layers
+
+        // -------------------------------------------------------------------------
+
+        private OVRInput.Controller _activeController = OVRInput.Controller.None;
+        private float _cooldownTimer;
+
+        // --- Public API ----------------------------------------------------------
+
+        /// <summary>
+        /// Set the controller to vibrate on impact. Call when the player grabs this object.
+        /// </summary>
+        public void SetActiveController(OVRInput.Controller controller)
+        {
+            _activeController = controller;
+        }
+
+        /// <summary>
+        /// Clear the active controller. Call when the player releases this object.
+        /// Impacts from non-held objects will produce no haptic feedback.
+        /// </summary>
+        public void ClearActiveController()
+        {
+            _activeController = OVRInput.Controller.None;
+        }
+
+        // --- Unity lifecycle -----------------------------------------------------
+
+        private void Update()
+        {
+            if (_cooldownTimer > 0f)
+                _cooldownTimer -= Time.deltaTime;
+        }
+
+        private void OnCollisionEnter(Collision collision)
+        {
+            // Skip if not currently held by a controller.
+            if (_activeController == OVRInput.Controller.None) return;
+
+            // Cooldown guard.
+            if (_cooldownTimer > 0f) return;
+
+            // Layer filter.
+            if ((collisionLayers.value & (1 << collision.gameObject.layer)) == 0) return;
+
+            // Compute impulse magnitude as a proxy for impact force.
+            float impulse = collision.impulse.magnitude;
+
+            if (impulse < minimumImpulse) return;
+
+            float clampedForce = Mathf.Min(impulse, maxImpulse);
+
+            TriggerImpactFeedback(clampedForce);
+            _cooldownTimer = cooldown;
+        }
+
+        // --- Internal ------------------------------------------------------------
+
+        private void TriggerImpactFeedback(float force)
+        {
+#if HAS_META_XR
+            if (HapticManager.Instance == null)
+            {
+                Debug.LogWarning("[HapticOnImpact] HapticManager not found in scene.");
+                return;
+            }
+            HapticManager.Instance.PlayImpact(_activeController, force);
+#else
+            Debug.Log($"[HapticOnImpact] Impact | ctrl={_activeController} force={force:F2}N");
+#endif
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Implements issue #37 -- haptic (vibration) feedback for Meta Quest 3 controllers.

- **HapticManager** (`Assets/Scripts/Feedback/HapticManager.cs`) -- persistent singleton wrapping `OVRInput.SetControllerVibration`. All five event types (Grab, Release, Impact, Heartbeat, Warning) have independently configurable amplitude / frequency / duration in the Inspector. Impact auto-selects light/medium/heavy tier based on force thresholds. Heartbeat and Warning run as coroutines.
- **HapticOnGrab** (`Assets/Scripts/Feedback/HapticOnGrab.cs`) -- `MonoBehaviour` to attach to any grabbable object. Exposes `OnGrab(controller)` and `OnRelease(controller)`. Mass influence is applied via an `AnimationCurve` (heavier objects = stronger grab pulse). Call from your grab system (OVRGrabbable, ISDK HandGrabInteractable, etc.).
- **HapticOnImpact** (`Assets/Scripts/Feedback/HapticOnImpact.cs`) -- `MonoBehaviour` using `OnCollisionEnter`. Measures `collision.impulse.magnitude`, applies minimum threshold + cooldown to suppress jitter, filters by `LayerMask`. Controller is set/cleared by the grab system via `SetActiveController()` / `ClearActiveController()`.

All files: `#if HAS_META_XR` guards -- without the define the methods fall back to `Debug.Log` so the project compiles in bare Editor. Namespace: `Plaga44.Feedback`. No existing files modified.

## Test plan

- [ ] Open Unity 6 with Meta XR SDK (HAS_META_XR defined)
- [ ] Add **HapticManager** to the OVRCameraRig GameObject
- [ ] Add **HapticOnGrab** + **HapticOnImpact** to a grabbable Rigidbody object
- [ ] In Play mode on device (Quest 3): grab object -- feel grab pulse in the grabbing controller
- [ ] Release object -- feel shorter release pulse
- [ ] Throw object at a wall -- feel impact strength proportional to velocity
- [ ] Call `HapticManager.Instance.PlayHeartbeat(OVRInput.Controller.LTouch)` from any script -- feel lub-dub pattern
- [ ] Call `HapticManager.Instance.PlayWarning(OVRInput.Controller.RTouch)` -- feel 3x warning bursts
- [ ] Without HAS_META_XR define: all calls produce `Debug.Log` output, no compile errors

Closes #37
Closes #37