### PR TITLE
feat: Mixed Reality -- passthrough + scene anchor mapper

### DIFF
--- a/Assets/Editor/MRSetup.cs
+++ b/Assets/Editor/MRSetup.cs
@@ -1,0 +1,163 @@
+#if UNITY_EDITOR
+using UnityEditor;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+
+#if HAS_META_XR
+using Plaga44.MixedReality;
+#endif
+
+namespace Plaga44.Editor
+{
+    /// <summary>
+    /// One-click Mixed Reality scene setup.
+    /// Menu: CYBERNOMAD / Scene Setup / Setup Mixed Reality
+    ///
+    /// What it does:
+    ///   1. Locates or creates OVRManager in the scene.
+    ///   2. Enables passthrough on OVRManager.
+    ///   3. Adds OVRPassthroughLayer to the OVRManager GameObject.
+    ///   4. Adds or locates OVRSceneManager in the scene.
+    ///   5. Adds PassthroughManager (runtime script) to the OVRManager GameObject.
+    ///   6. Adds SceneAnchorMapper to the OVRSceneManager GameObject.
+    ///   7. Marks the scene dirty so Unity prompts to save.
+    /// </summary>
+    public static class MRSetup
+    {
+        private const string LOG = "[PLAGA44]";
+
+        [MenuItem("CYBERNOMAD/Scene Setup/Setup Mixed Reality", false, 110)]
+        public static void SetupMixedReality()
+        {
+            Debug.Log($"{LOG} === Setup Mixed Reality ===");
+
+#if !HAS_META_XR
+            Debug.LogWarning($"{LOG} HAS_META_XR is not defined. " +
+                             "Install Meta XR SDK and add HAS_META_XR to Scripting Define Symbols " +
+                             "before running this setup. " +
+                             "(CYBERNOMAD / Meta SDK Setup / 1. Setup Meta SDK)");
+            EditorUtility.DisplayDialog(
+                "Meta XR SDK Required",
+                "HAS_META_XR scripting define is missing.\n\n" +
+                "Run: CYBERNOMAD > Meta SDK Setup > 1. Setup Meta SDK\n" +
+                "then add HAS_META_XR to Player Settings > Scripting Define Symbols.",
+                "OK");
+            return;
+#else
+            SetupOVRManager();
+            SetupOVRSceneManager();
+
+            UnityEditor.SceneManagement.EditorSceneManager.MarkSceneDirty(
+                UnityEditor.SceneManagement.EditorSceneManager.GetActiveScene());
+
+            Debug.Log($"{LOG} === Mixed Reality setup complete. Save the scene. ===");
+            EditorUtility.DisplayDialog(
+                "Mixed Reality Setup",
+                "Setup complete!\n\n" +
+                "Components added:\n" +
+                "  - OVRPassthroughLayer (on OVRManager)\n" +
+                "  - PassthroughManager  (on OVRManager)\n" +
+                "  - OVRSceneManager     (in scene)\n" +
+                "  - SceneAnchorMapper   (on OVRSceneManager)\n\n" +
+                "Next steps:\n" +
+                "1. Assign gameplay prefabs in SceneAnchorMapper > Mappings.\n" +
+                "2. Add PassthroughPortal to any trigger collider for VR<->MR transitions.\n" +
+                "3. Build to Quest 3 and run Quest Space Setup if not already done.",
+                "OK");
+#endif
+        }
+
+#if HAS_META_XR
+        // ------------------------------------------------------------------ //
+        //  OVRManager                                                         //
+        // ------------------------------------------------------------------ //
+
+        private static void SetupOVRManager()
+        {
+            var ovrManager = FindOrCreateOVRManager();
+
+            // Enable passthrough
+            ovrManager.isInsightPassthroughEnabled = true;
+            Debug.Log($"{LOG} OVRManager.isInsightPassthroughEnabled = true");
+
+            // Add OVRPassthroughLayer if missing
+            var passthroughLayer = ovrManager.GetComponent<OVRPassthroughLayer>();
+            if (passthroughLayer == null)
+            {
+                passthroughLayer = Undo.AddComponent<OVRPassthroughLayer>(ovrManager.gameObject);
+                passthroughLayer.projectionSurfaceType = OVRPassthroughLayer.ProjectionSurfaceType.Reconstruction;
+                Debug.Log($"{LOG} Added OVRPassthroughLayer (Reconstruction surface)");
+            }
+            else
+            {
+                Debug.Log($"{LOG} OVRPassthroughLayer already present -- skipped");
+            }
+
+            // Add PassthroughManager runtime script if missing
+            var ptManager = ovrManager.GetComponent<PassthroughManager>();
+            if (ptManager == null)
+            {
+                Undo.AddComponent<PassthroughManager>(ovrManager.gameObject);
+                Debug.Log($"{LOG} Added PassthroughManager");
+            }
+            else
+            {
+                Debug.Log($"{LOG} PassthroughManager already present -- skipped");
+            }
+        }
+
+        private static OVRManager FindOrCreateOVRManager()
+        {
+            var existing = Object.FindObjectOfType<OVRManager>();
+            if (existing != null)
+            {
+                Debug.Log($"{LOG} Found existing OVRManager on '{existing.gameObject.name}'");
+                return existing;
+            }
+
+            Debug.Log($"{LOG} No OVRManager found -- creating OVRCameraRig");
+            var ovrCameraRig = new GameObject("OVRCameraRig");
+            Undo.RegisterCreatedObjectUndo(ovrCameraRig, "Create OVRCameraRig");
+
+            var manager = Undo.AddComponent<OVRManager>(ovrCameraRig);
+            Undo.AddComponent<OVRCameraRig>(ovrCameraRig);
+
+            return manager;
+        }
+
+        // ------------------------------------------------------------------ //
+        //  OVRSceneManager                                                    //
+        // ------------------------------------------------------------------ //
+
+        private static void SetupOVRSceneManager()
+        {
+            var sceneManager = Object.FindObjectOfType<OVRSceneManager>();
+
+            if (sceneManager == null)
+            {
+                var go = new GameObject("OVRSceneManager");
+                Undo.RegisterCreatedObjectUndo(go, "Create OVRSceneManager");
+                sceneManager = Undo.AddComponent<OVRSceneManager>(go);
+                Debug.Log($"{LOG} Created OVRSceneManager GameObject");
+            }
+            else
+            {
+                Debug.Log($"{LOG} OVRSceneManager already present on '{sceneManager.gameObject.name}'");
+            }
+
+            // Add SceneAnchorMapper if missing
+            var mapper = sceneManager.GetComponent<SceneAnchorMapper>();
+            if (mapper == null)
+            {
+                Undo.AddComponent<SceneAnchorMapper>(sceneManager.gameObject);
+                Debug.Log($"{LOG} Added SceneAnchorMapper");
+            }
+            else
+            {
+                Debug.Log($"{LOG} SceneAnchorMapper already present -- skipped");
+            }
+        }
+#endif // HAS_META_XR
+    }
+}
+#endif // UNITY_EDITOR

--- a/Assets/Scripts/MixedReality/PassthroughManager.cs
+++ b/Assets/Scripts/MixedReality/PassthroughManager.cs
@@ -1,0 +1,187 @@
+#if HAS_META_XR
+using System.Collections;
+using UnityEngine;
+
+namespace Plaga44.MixedReality
+{
+    /// <summary>
+    /// Manages the Meta Quest passthrough layer.
+    /// Attach to the same GameObject as OVRManager (or a dedicated MR manager object).
+    /// Exposes VR/MR toggle, opacity, edge rendering, and a colour LUT texture.
+    /// </summary>
+    [RequireComponent(typeof(OVRPassthroughLayer))]
+    public class PassthroughManager : MonoBehaviour
+    {
+        // ------------------------------------------------------------------ //
+        //  Inspector fields                                                   //
+        // ------------------------------------------------------------------ //
+
+        [Header("Passthrough layer")]
+        [Tooltip("Reference to the OVRPassthroughLayer added to this GameObject.")]
+        [SerializeField] private OVRPassthroughLayer _passthroughLayer;
+
+        [Header("Opacity")]
+        [Range(0f, 1f)]
+        [SerializeField] private float _opacity = 1f;
+
+        [Header("Edge rendering")]
+        [SerializeField] private bool _edgeRenderingEnabled = false;
+        [SerializeField] private Color _edgeColor = new Color(1f, 0.5f, 0f, 1f); // post-apo orange
+
+        [Header("Colour LUT")]
+        [Tooltip("Optional colour LUT texture (256x1 or 16x16x16). Leave null to skip.")]
+        [SerializeField] private Texture2D _colorLUT;
+        [Range(0f, 1f)]
+        [SerializeField] private float _lutWeight = 1f;
+
+        [Header("Fade")]
+        [Tooltip("Duration of VR<->MR crossfade in seconds.")]
+        [SerializeField] private float _fadeDuration = 1.0f;
+
+        // ------------------------------------------------------------------ //
+        //  Runtime state                                                      //
+        // ------------------------------------------------------------------ //
+
+        private bool _isMRActive = false;
+        private Coroutine _fadeCoroutine;
+
+        // ------------------------------------------------------------------ //
+        //  Unity lifecycle                                                    //
+        // ------------------------------------------------------------------ //
+
+        private void Awake()
+        {
+            if (_passthroughLayer == null)
+                _passthroughLayer = GetComponent<OVRPassthroughLayer>();
+
+            // Start in VR mode -- passthrough hidden
+            ApplyPassthroughSettings(visible: false, opacity: 0f);
+        }
+
+        private void OnValidate()
+        {
+            if (_passthroughLayer == null) return;
+            ApplyPassthroughSettings(_isMRActive, _opacity);
+        }
+
+        // ------------------------------------------------------------------ //
+        //  Public API                                                         //
+        // ------------------------------------------------------------------ //
+
+        /// <summary>Returns true when passthrough (MR mode) is currently active.</summary>
+        public bool IsMRActive => _isMRActive;
+
+        /// <summary>Toggles between VR (no passthrough) and MR (passthrough visible).</summary>
+        public void ToggleMode()
+        {
+            SetMRMode(!_isMRActive);
+        }
+
+        /// <summary>
+        /// Switches to MR mode (passthrough on) or VR mode (passthrough off).
+        /// Uses a coroutine fade so the transition is smooth.
+        /// </summary>
+        public void SetMRMode(bool enable)
+        {
+            if (_fadeCoroutine != null)
+                StopCoroutine(_fadeCoroutine);
+
+            _isMRActive = enable;
+            _fadeCoroutine = StartCoroutine(FadeOpacity(enable ? _opacity : 0f));
+        }
+
+        /// <summary>Sets passthrough opacity (0=transparent, 1=fully opaque).</summary>
+        public void SetOpacity(float opacity)
+        {
+            _opacity = Mathf.Clamp01(opacity);
+            if (_isMRActive)
+                _passthroughLayer.textureOpacity = _opacity;
+        }
+
+        /// <summary>Enables or disables edge rendering overlay.</summary>
+        public void SetEdgeRendering(bool enabled, Color? color = null)
+        {
+            _edgeRenderingEnabled = enabled;
+            if (color.HasValue) _edgeColor = color.Value;
+            ApplyEdgeRendering();
+        }
+
+        /// <summary>Applies a colour LUT to the passthrough layer.</summary>
+        public void SetColorLUT(Texture2D lut, float weight = 1f)
+        {
+            _colorLUT = lut;
+            _lutWeight = Mathf.Clamp01(weight);
+            ApplyColorLUT();
+        }
+
+        // ------------------------------------------------------------------ //
+        //  Internal helpers                                                   //
+        // ------------------------------------------------------------------ //
+
+        private void ApplyPassthroughSettings(bool visible, float opacity)
+        {
+            if (_passthroughLayer == null) return;
+
+            _passthroughLayer.hidden = !visible;
+            _passthroughLayer.textureOpacity = opacity;
+
+            if (visible)
+            {
+                ApplyEdgeRendering();
+                ApplyColorLUT();
+            }
+        }
+
+        private void ApplyEdgeRendering()
+        {
+            if (_passthroughLayer == null) return;
+
+            _passthroughLayer.edgeRenderingEnabled = _edgeRenderingEnabled;
+            if (_edgeRenderingEnabled)
+                _passthroughLayer.edgeColor = _edgeColor;
+        }
+
+        private void ApplyColorLUT()
+        {
+            if (_passthroughLayer == null || _colorLUT == null) return;
+
+            // OVRPassthroughLayer.SetColorLut is available in Meta XR SDK >= v60
+            _passthroughLayer.SetColorLut(_colorLUT, _lutWeight);
+        }
+
+        private IEnumerator FadeOpacity(float targetOpacity)
+        {
+            float startOpacity = _passthroughLayer.textureOpacity;
+
+            // Make layer visible before fading in
+            if (targetOpacity > 0f)
+                _passthroughLayer.hidden = false;
+
+            float elapsed = 0f;
+            while (elapsed < _fadeDuration)
+            {
+                elapsed += Time.deltaTime;
+                float t = Mathf.Clamp01(elapsed / _fadeDuration);
+                _passthroughLayer.textureOpacity = Mathf.Lerp(startOpacity, targetOpacity, t);
+                yield return null;
+            }
+
+            _passthroughLayer.textureOpacity = targetOpacity;
+
+            // Hide layer after fading out to save GPU cost
+            if (targetOpacity <= 0f)
+            {
+                _passthroughLayer.hidden = true;
+                ApplyEdgeRendering(); // resets edge state
+            }
+            else
+            {
+                ApplyEdgeRendering();
+                ApplyColorLUT();
+            }
+
+            _fadeCoroutine = null;
+        }
+    }
+}
+#endif // HAS_META_XR

--- a/Assets/Scripts/MixedReality/PassthroughPortal.cs
+++ b/Assets/Scripts/MixedReality/PassthroughPortal.cs
@@ -1,0 +1,110 @@
+#if HAS_META_XR
+using System.Collections;
+using UnityEngine;
+
+namespace Plaga44.MixedReality
+{
+    /// <summary>
+    /// Trigger collider portal that switches between VR and MR mode when the
+    /// player enters. Requires a <see cref="PassthroughManager"/> in the scene.
+    ///
+    /// Gameplay meaning:
+    ///   - Walking INTO the portal  --> switches to MR (your room = the bunker)
+    ///   - Walking OUT of the portal --> switches back to VR (underground)
+    ///
+    /// Attach to a GameObject with a Collider set as Trigger.
+    /// The OVRCameraRig (or its CenterEyeAnchor) must have a Rigidbody (kinematic)
+    /// or you can tag the player with the playerTag field below.
+    /// </summary>
+    [RequireComponent(typeof(Collider))]
+    public class PassthroughPortal : MonoBehaviour
+    {
+        // ------------------------------------------------------------------ //
+        //  Inspector fields                                                   //
+        // ------------------------------------------------------------------ //
+
+        [Header("References")]
+        [Tooltip("PassthroughManager in the scene. Auto-located if left empty.")]
+        [SerializeField] private PassthroughManager _passthroughManager;
+
+        [Header("Portal behaviour")]
+        [Tooltip("Tag used to identify the VR player object (OVRCameraRig or head).")]
+        [SerializeField] private string _playerTag = "MainCamera";
+
+        [Tooltip("When true, entering the portal enables MR; exiting disables it. " +
+                 "When false, each entry toggles the current mode.")]
+        [SerializeField] private bool _enterEnablesMR = true;
+
+        [Header("Visual feedback")]
+        [Tooltip("Optional renderer on the portal frame -- changes emissive on activation.")]
+        [SerializeField] private Renderer _portalFrameRenderer;
+        [SerializeField] private Color _vrModeFrameColor  = new Color(0.0f, 0.4f, 1.0f);
+        [SerializeField] private Color _mrModeFrameColor  = new Color(1.0f, 0.5f, 0.0f);
+
+        // ------------------------------------------------------------------ //
+        //  Unity lifecycle                                                    //
+        // ------------------------------------------------------------------ //
+
+        private void Awake()
+        {
+            var col = GetComponent<Collider>();
+            col.isTrigger = true;
+
+            if (_passthroughManager == null)
+                _passthroughManager = FindObjectOfType<PassthroughManager>();
+
+            UpdateFrameColor();
+        }
+
+        // ------------------------------------------------------------------ //
+        //  Trigger callbacks                                                  //
+        // ------------------------------------------------------------------ //
+
+        private void OnTriggerEnter(Collider other)
+        {
+            if (!IsPlayer(other)) return;
+
+            if (_enterEnablesMR)
+                _passthroughManager?.SetMRMode(true);
+            else
+                _passthroughManager?.ToggleMode();
+
+            UpdateFrameColor();
+        }
+
+        private void OnTriggerExit(Collider other)
+        {
+            if (!IsPlayer(other)) return;
+
+            if (_enterEnablesMR)
+                _passthroughManager?.SetMRMode(false);
+            // In toggle mode, exit does nothing -- next entry will toggle
+
+            UpdateFrameColor();
+        }
+
+        // ------------------------------------------------------------------ //
+        //  Helpers                                                            //
+        // ------------------------------------------------------------------ //
+
+        private bool IsPlayer(Collider other)
+        {
+            return other.CompareTag(_playerTag);
+        }
+
+        private void UpdateFrameColor()
+        {
+            if (_portalFrameRenderer == null) return;
+
+            bool mrActive = _passthroughManager != null && _passthroughManager.IsMRActive;
+            Color target = mrActive ? _mrModeFrameColor : _vrModeFrameColor;
+
+            // Use MaterialPropertyBlock to avoid creating new material instances
+            var mpb = new MaterialPropertyBlock();
+            _portalFrameRenderer.GetPropertyBlock(mpb);
+            mpb.SetColor("_EmissionColor", target);
+            _portalFrameRenderer.SetPropertyBlock(mpb);
+        }
+    }
+}
+#endif // HAS_META_XR

--- a/Assets/Scripts/MixedReality/SceneAnchorMapper.cs
+++ b/Assets/Scripts/MixedReality/SceneAnchorMapper.cs
@@ -1,0 +1,221 @@
+#if HAS_META_XR
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace Plaga44.MixedReality
+{
+    /// <summary>
+    /// Uses OVRSceneManager to discover room anchors and maps real-world furniture
+    /// to PLAGA '44 gameplay props.
+    ///
+    /// Semantic labels supported:
+    ///   TABLE       --> shelter table (crafting surface)
+    ///   COUCH       --> medical cot (rest/healing)
+    ///   WALL_FACE   --> bunker wall (decoration / occlusion mesh)
+    ///   FLOOR       --> bunker floor (navigation mesh base)
+    ///   CEILING     --> bunker ceiling (decoration)
+    ///   WINDOW_FRAME --> bunker observation window
+    ///   DOOR_FRAME  --> bunker entrance
+    ///
+    /// Attach to the same GameObject as OVRSceneManager.
+    /// Assign prefabs for each label in the inspector.
+    /// </summary>
+    [RequireComponent(typeof(OVRSceneManager))]
+    public class SceneAnchorMapper : MonoBehaviour
+    {
+        // ------------------------------------------------------------------ //
+        //  Mapping entry                                                      //
+        // ------------------------------------------------------------------ //
+
+        [System.Serializable]
+        public class SemanticMapping
+        {
+            [Tooltip("OVR semantic label, e.g. TABLE, COUCH, WALL_FACE, FLOOR, CEILING")]
+            public string semanticLabel = "TABLE";
+
+            [Tooltip("Gameplay prefab to spawn at this anchor.")]
+            public GameObject prefab;
+
+            [Tooltip("Vertical offset applied when placing the prefab (metres).")]
+            public float yOffset = 0f;
+
+            [Tooltip("Uniform scale multiplier applied to the spawned prefab.")]
+            public float scaleFactor = 1f;
+        }
+
+        // ------------------------------------------------------------------ //
+        //  Inspector fields                                                   //
+        // ------------------------------------------------------------------ //
+
+        [Header("OVRSceneManager")]
+        [SerializeField] private OVRSceneManager _sceneManager;
+
+        [Header("Semantic -> Gameplay mappings")]
+        [SerializeField]
+        private List<SemanticMapping> _mappings = new List<SemanticMapping>
+        {
+            new SemanticMapping { semanticLabel = "TABLE",       yOffset = 0f,    scaleFactor = 1f },
+            new SemanticMapping { semanticLabel = "COUCH",       yOffset = 0f,    scaleFactor = 1f },
+            new SemanticMapping { semanticLabel = "WALL_FACE",   yOffset = 0f,    scaleFactor = 1f },
+            new SemanticMapping { semanticLabel = "FLOOR",       yOffset = 0f,    scaleFactor = 1f },
+            new SemanticMapping { semanticLabel = "CEILING",     yOffset = 0f,    scaleFactor = 1f },
+            new SemanticMapping { semanticLabel = "WINDOW_FRAME",yOffset = 0f,    scaleFactor = 1f },
+            new SemanticMapping { semanticLabel = "DOOR_FRAME",  yOffset = 0f,    scaleFactor = 1f },
+        };
+
+        [Header("Fallback")]
+        [Tooltip("Prefab used when a detected anchor has no matching semantic mapping.")]
+        [SerializeField] private GameObject _unknownAnchorPrefab;
+
+        // ------------------------------------------------------------------ //
+        //  Runtime                                                            //
+        // ------------------------------------------------------------------ //
+
+        // Dictionary for O(1) lookup: label --> mapping
+        private Dictionary<string, SemanticMapping> _mappingLookup;
+
+        // All spawned gameplay props, keyed by anchor UUID string
+        private Dictionary<string, GameObject> _spawnedProps = new Dictionary<string, GameObject>();
+
+        // ------------------------------------------------------------------ //
+        //  Unity lifecycle                                                    //
+        // ------------------------------------------------------------------ //
+
+        private void Awake()
+        {
+            if (_sceneManager == null)
+                _sceneManager = GetComponent<OVRSceneManager>();
+
+            BuildLookup();
+        }
+
+        private void OnEnable()
+        {
+            _sceneManager.SceneModelLoadedSuccessfully += OnSceneModelLoaded;
+            _sceneManager.NoSceneModelToLoad            += OnNoSceneModel;
+        }
+
+        private void OnDisable()
+        {
+            _sceneManager.SceneModelLoadedSuccessfully -= OnSceneModelLoaded;
+            _sceneManager.NoSceneModelToLoad            -= OnNoSceneModel;
+        }
+
+        // ------------------------------------------------------------------ //
+        //  OVRSceneManager callbacks                                         //
+        // ------------------------------------------------------------------ //
+
+        private void OnSceneModelLoaded()
+        {
+            Debug.Log("[PLAGA44] Scene model loaded. Mapping anchors to gameplay objects.");
+            MapAllAnchors();
+        }
+
+        private void OnNoSceneModel()
+        {
+            Debug.LogWarning("[PLAGA44] No Scene Model available on this device. " +
+                             "Ask user to run Space Setup in Quest settings.");
+        }
+
+        // ------------------------------------------------------------------ //
+        //  Mapping logic                                                      //
+        // ------------------------------------------------------------------ //
+
+        private void MapAllAnchors()
+        {
+            // OVRSceneAnchor is the runtime component added to each discovered anchor
+            var anchors = FindObjectsOfType<OVRSceneAnchor>();
+            Debug.Log($"[PLAGA44] Found {anchors.Length} scene anchors.");
+
+            foreach (var anchor in anchors)
+                MapAnchor(anchor);
+        }
+
+        private void MapAnchor(OVRSceneAnchor anchor)
+        {
+            string uuid = anchor.Uuid.ToString();
+
+            // Already mapped (e.g. after scene model refresh)
+            if (_spawnedProps.ContainsKey(uuid)) return;
+
+            // Determine semantic label from OVRSemanticClassification
+            string label = GetSemanticLabel(anchor.gameObject);
+
+            GameObject prefabToSpawn = null;
+            float yOffset = 0f;
+            float scale   = 1f;
+
+            if (label != null && _mappingLookup.TryGetValue(label, out var mapping))
+            {
+                prefabToSpawn = mapping.prefab;
+                yOffset       = mapping.yOffset;
+                scale         = mapping.scaleFactor;
+            }
+            else
+            {
+                prefabToSpawn = _unknownAnchorPrefab;
+                Debug.Log($"[PLAGA44] Anchor {uuid} -- label '{label ?? "none"}' has no mapping, using fallback.");
+            }
+
+            if (prefabToSpawn == null)
+            {
+                // No prefab configured for this label -- skip silently
+                _spawnedProps[uuid] = null;
+                return;
+            }
+
+            // Spawn parented to the anchor so it tracks with the physical object
+            Vector3 spawnPos = anchor.transform.position + Vector3.up * yOffset;
+            GameObject prop  = Instantiate(prefabToSpawn, spawnPos, anchor.transform.rotation, anchor.transform);
+            prop.transform.localScale = Vector3.one * scale;
+            prop.name = $"[MR] {label ?? "Unknown"}_{uuid.Substring(0, 8)}";
+
+            _spawnedProps[uuid] = prop;
+
+            Debug.Log($"[PLAGA44] Mapped anchor '{label}' ({uuid.Substring(0, 8)}) --> {prop.name}");
+        }
+
+        private string GetSemanticLabel(GameObject anchorGO)
+        {
+            var classification = anchorGO.GetComponent<OVRSemanticClassification>();
+            if (classification == null) return null;
+
+            // OVRSemanticClassification.Labels is a List<string>
+            if (classification.Labels != null && classification.Labels.Count > 0)
+                return classification.Labels[0].ToUpper();
+
+            return null;
+        }
+
+        private void BuildLookup()
+        {
+            _mappingLookup = new Dictionary<string, SemanticMapping>(_mappings.Count);
+            foreach (var m in _mappings)
+            {
+                string key = m.semanticLabel.ToUpper();
+                if (!_mappingLookup.ContainsKey(key))
+                    _mappingLookup[key] = m;
+                else
+                    Debug.LogWarning($"[PLAGA44] Duplicate semantic label in SceneAnchorMapper: {key}");
+            }
+        }
+
+        // ------------------------------------------------------------------ //
+        //  Public API                                                         //
+        // ------------------------------------------------------------------ //
+
+        /// <summary>Returns the spawned gameplay prop for the given anchor UUID, or null.</summary>
+        public GameObject GetPropForAnchor(string uuid)
+        {
+            _spawnedProps.TryGetValue(uuid, out var go);
+            return go;
+        }
+
+        /// <summary>Forces a remap of all current scene anchors (e.g. after scene refresh).</summary>
+        public void RemapAll()
+        {
+            MapAllAnchors();
+        }
+    }
+}
+#endif // HAS_META_XR


### PR DESCRIPTION
## Summary

Closes #38

- **PassthroughManager** -- MonoBehaviour on OVRManager. Enables/disables `OVRPassthroughLayer` with configurable opacity, edge rendering (colour), and colour LUT. Smooth coroutine fade on VR<->MR toggle.
- **PassthroughPortal** -- MonoBehaviour on a trigger Collider. Player enters portal = MR mode on; player exits = MR mode off (or toggle). Optional emissive frame colour feedback.
- **SceneAnchorMapper** -- MonoBehaviour on OVRSceneManager. Subscribes to `SceneModelLoadedSuccessfully`, discovers all `OVRSceneAnchor` objects, reads `OVRSemanticClassification.Labels`, and instantiates configured gameplay prefabs. Supported labels: `TABLE`, `COUCH`, `WALL_FACE`, `FLOOR`, `CEILING`, `WINDOW_FRAME`, `DOOR_FRAME`.
- **MRSetup** (Editor) -- menu `CYBERNOMAD / Scene Setup / Setup Mixed Reality`. Finds or creates OVRManager, enables passthrough, adds `OVRPassthroughLayer` + `PassthroughManager`, creates `OVRSceneManager` + `SceneAnchorMapper` one-click. Shows error dialog when `HAS_META_XR` is missing.

All runtime scripts are wrapped in `#if HAS_META_XR`.

## How to test

### Without Quest device (Editor)

1. Open Unity 6 editor with this branch.
2. With `HAS_META_XR` **not** defined: run `CYBERNOMAD > Scene Setup > Setup Mixed Reality` -- expect warning dialog "Meta XR SDK Required".
3. Add `HAS_META_XR` to `Player Settings > Scripting Define Symbols`, wait for recompile.
4. Run `CYBERNOMAD > Scene Setup > Setup Mixed Reality` again -- expect success dialog and scene objects `OVRCameraRig` (with `OVRPassthroughLayer` + `PassthroughManager`) and `OVRSceneManager` (with `SceneAnchorMapper`) in the hierarchy.
5. Verify no compile errors in Console.

### On Quest 3 device (full MR test)

1. Run Space Setup on Quest if not already done.
2. Build & run to Quest 3 (Android, IL2CPP, ARM64).
3. On launch the scene should be in full VR (passthrough hidden).
4. Walk through a `PassthroughPortal` collider -- passthrough fades in, real room visible.
5. Scene anchors auto-map: table shows shelter table prefab, couch shows medical cot prefab (after assigning prefabs in `SceneAnchorMapper` inspector).
6. Walk back out of portal -- passthrough fades out, back to VR.