### PR TITLE
Eye tracking system -- Quest Pro/Quest 3 (closes #32)

### DIFF
--- a/Assets/Scripts/EyeTracking/EyeTrackingManager.cs
+++ b/Assets/Scripts/EyeTracking/EyeTrackingManager.cs
@@ -1,0 +1,210 @@
+// EyeTrackingManager.cs
+// PLAGA '44 -- Eye tracking manager for Meta Quest Pro / Quest 3.
+// Initializes OVREyeGaze and exposes public gaze API.
+//
+// Requires: com.meta.xr.sdk.core (OVREyeGaze) -- guarded by HAS_META_XR.
+// Namespace: Plaga44.EyeTracking
+
+using UnityEngine;
+
+namespace Plaga44.EyeTracking
+{
+    /// <summary>
+    /// Manages eye tracking via OVREyeGaze (Meta XR SDK).
+    /// Attach to a persistent GameObject (e.g. XR Rig root).
+    /// </summary>
+    public class EyeTrackingManager : MonoBehaviour
+    {
+        private const string LOG = "[EyeTracking]";
+
+        [Header("References")]
+        [Tooltip("Main camera / center eye transform used as fallback origin.")]
+        [SerializeField] private Transform _cameraRoot;
+
+        [Header("Settings")]
+        [Tooltip("Minimum confidence threshold to consider gaze valid.")]
+        [SerializeField][Range(0f, 1f)] private float _minConfidence = 0.5f;
+
+        [Tooltip("Lerp speed for smoothing combined gaze direction.")]
+        [SerializeField][Range(1f, 60f)] private float _smoothSpeed = 20f;
+
+        // ── State ────────────────────────────────────────────────────────
+
+        private bool _eyeTrackingAvailable = false;
+        private Vector3 _smoothedGazeDir = Vector3.forward;
+
+#if HAS_META_XR
+        private OVREyeGaze _leftEye;
+        private OVREyeGaze _rightEye;
+#endif
+
+        // ── Unity lifecycle ──────────────────────────────────────────────
+
+        private void Awake()
+        {
+            if (_cameraRoot == null)
+            {
+#if HAS_META_XR
+                var rig = FindFirstObjectByType<OVRCameraRig>();
+                if (rig != null)
+                    _cameraRoot = rig.centerEyeAnchor;
+#endif
+                if (_cameraRoot == null && Camera.main != null)
+                    _cameraRoot = Camera.main.transform;
+            }
+
+#if HAS_META_XR
+            InitOVREyeGaze();
+#else
+            Debug.LogWarning($"{LOG} HAS_META_XR not defined -- eye tracking unavailable. " +
+                             "Install Meta XR SDK and ensure the scripting define is set.");
+#endif
+        }
+
+#if HAS_META_XR
+        private void InitOVREyeGaze()
+        {
+            // OVREyeGaze components are expected on child anchors of OVRCameraRig.
+            // If not present, create lightweight proxies.
+            var eyes = GetComponentsInChildren<OVREyeGaze>(true);
+            foreach (var eye in eyes)
+            {
+                if (eye.Eye == OVREyeGaze.EyeId.Left)  _leftEye  = eye;
+                if (eye.Eye == OVREyeGaze.EyeId.Right) _rightEye = eye;
+            }
+
+            if (_leftEye == null && _rightEye == null)
+            {
+                // Try finding anywhere in scene
+                var allEyes = FindObjectsByType<OVREyeGaze>(FindObjectsSortMode.None);
+                foreach (var eye in allEyes)
+                {
+                    if (eye.Eye == OVREyeGaze.EyeId.Left  && _leftEye  == null) _leftEye  = eye;
+                    if (eye.Eye == OVREyeGaze.EyeId.Right && _rightEye == null) _rightEye = eye;
+                }
+            }
+
+            bool permissionGranted = OVRPlugin.eyeTrackingEnabled;
+            _eyeTrackingAvailable = permissionGranted && (_leftEye != null || _rightEye != null);
+
+            if (_eyeTrackingAvailable)
+                Debug.Log($"{LOG} Eye tracking initialized. L={_leftEye != null} R={_rightEye != null}");
+            else
+                Debug.LogWarning($"{LOG} Eye tracking not available. " +
+                                 $"Permission={permissionGranted}, L={_leftEye != null}, R={_rightEye != null}. " +
+                                 "Ensure EyeTracking permission is set in Meta XR Project Setup Tool.");
+        }
+#endif
+
+        private void Update()
+        {
+            if (!_eyeTrackingAvailable) return;
+
+            Vector3 combinedDir = GetRawCombinedDirection();
+            _smoothedGazeDir = Vector3.Slerp(
+                _smoothedGazeDir,
+                combinedDir,
+                Time.deltaTime * _smoothSpeed);
+        }
+
+        // ── Public API ───────────────────────────────────────────────────
+
+        /// <summary>
+        /// Returns a world-space Ray for the requested eye.
+        /// Falls back to center eye (averaged) if the specific eye is unavailable.
+        /// </summary>
+        /// <param name="eye">Which eye to query (Left, Right, or Center for combined).</param>
+        public Ray GetGazeDirection(GazeEye eye = GazeEye.Center)
+        {
+            Vector3 origin = _cameraRoot != null ? _cameraRoot.position : Vector3.zero;
+
+#if HAS_META_XR
+            if (_eyeTrackingAvailable)
+            {
+                OVREyeGaze source = null;
+                switch (eye)
+                {
+                    case GazeEye.Left:   source = _leftEye  ?? _rightEye; break;
+                    case GazeEye.Right:  source = _rightEye ?? _leftEye;  break;
+                    case GazeEye.Center: source = null; break;
+                }
+
+                if (source != null && source.EyeTrackingEnabled && source.Confidence >= _minConfidence)
+                    return new Ray(source.transform.position, source.transform.forward);
+
+                // Center: average valid eyes
+                if (eye == GazeEye.Center)
+                    return new Ray(origin, _smoothedGazeDir);
+            }
+#endif
+            // Fallback: camera forward
+            Vector3 fallbackDir = _cameraRoot != null ? _cameraRoot.forward : Vector3.forward;
+            return new Ray(origin, fallbackDir);
+        }
+
+        /// <summary>
+        /// Returns the confidence of the combined gaze [0..1].
+        /// 0 if eye tracking is unavailable or below threshold.
+        /// </summary>
+        public float GetGazeConfidence()
+        {
+#if HAS_META_XR
+            if (!_eyeTrackingAvailable) return 0f;
+
+            float total = 0f;
+            int count = 0;
+            if (_leftEye  != null && _leftEye.EyeTrackingEnabled)  { total += _leftEye.Confidence;  count++; }
+            if (_rightEye != null && _rightEye.EyeTrackingEnabled) { total += _rightEye.Confidence; count++; }
+            return count > 0 ? total / count : 0f;
+#else
+            return 0f;
+#endif
+        }
+
+        /// <summary>
+        /// Returns true if the player is looking at the target within the given angular tolerance (degrees).
+        /// Uses the combined smoothed gaze ray.
+        /// </summary>
+        public bool IsLookingAt(Transform target, float angleTolerance = 5f)
+        {
+            if (target == null) return false;
+
+            Ray gaze = GetGazeDirection(GazeEye.Center);
+            Vector3 toTarget = (target.position - gaze.origin).normalized;
+            float angle = Vector3.Angle(gaze.direction, toTarget);
+            return angle <= angleTolerance;
+        }
+
+        /// <summary>
+        /// Whether eye tracking hardware and permissions are available on this device.
+        /// </summary>
+        public bool IsEyeTrackingAvailable => _eyeTrackingAvailable;
+
+        // ── Helpers ──────────────────────────────────────────────────────
+
+        private Vector3 GetRawCombinedDirection()
+        {
+#if HAS_META_XR
+            Vector3 sum = Vector3.zero;
+            int count = 0;
+
+            if (_leftEye  != null && _leftEye.EyeTrackingEnabled  && _leftEye.Confidence  >= _minConfidence)
+            { sum += _leftEye.transform.forward;  count++; }
+            if (_rightEye != null && _rightEye.EyeTrackingEnabled && _rightEye.Confidence >= _minConfidence)
+            { sum += _rightEye.transform.forward; count++; }
+
+            if (count > 0)
+                return sum.normalized;
+#endif
+            return _cameraRoot != null ? _cameraRoot.forward : Vector3.forward;
+        }
+    }
+
+    /// <summary>Which eye to use for gaze queries.</summary>
+    public enum GazeEye
+    {
+        Left,
+        Right,
+        Center
+    }
+}

--- a/Assets/Scripts/EyeTracking/GazeDebug.cs
+++ b/Assets/Scripts/EyeTracking/GazeDebug.cs
@@ -1,0 +1,200 @@
+// GazeDebug.cs
+// PLAGA '44 -- Debug visualizer for eye tracking.
+// Draws gaze rays in Scene view (Debug.DrawRay) and optionally a world-space
+// indicator showing what the player is currently looking at.
+//
+// Editor-only visualization is always compiled; runtime indicator
+// can be toggled via Inspector.
+// Namespace: Plaga44.EyeTracking
+
+using UnityEngine;
+
+namespace Plaga44.EyeTracking
+{
+    /// <summary>
+    /// Attach alongside EyeTrackingManager to visualize gaze in the Scene view
+    /// and (optionally) with a runtime indicator sphere.
+    /// </summary>
+    public class GazeDebug : MonoBehaviour
+    {
+        // ── Inspector ─────────────────────────────────────────────────────
+
+        [Header("Ray Visualization")]
+        [SerializeField] private bool  _showLeftEye   = true;
+        [SerializeField] private bool  _showRightEye  = true;
+        [SerializeField] private bool  _showCombined  = true;
+
+        [SerializeField] private Color _leftEyeColor    = new Color(0.2f, 0.6f, 1f, 1f);
+        [SerializeField] private Color _rightEyeColor   = new Color(1f, 0.4f, 0.2f, 1f);
+        [SerializeField] private Color _combinedColor   = Color.green;
+        [SerializeField] private Color _lowConfColor    = new Color(1f, 1f, 0f, 0.5f);
+
+        [SerializeField][Range(0.1f, 20f)] private float _rayLength = 5f;
+
+        [Header("Hit Indicator")]
+        [Tooltip("Show a world-space sphere at the gaze hit point.")]
+        [SerializeField] private bool  _showHitIndicator = true;
+
+        [Tooltip("Layer mask for gaze raycast against scene geometry.")]
+        [SerializeField] private LayerMask _hitLayers = ~0;
+
+        [Tooltip("Radius of the debug hit sphere.")]
+        [SerializeField] private float _hitSphereRadius = 0.03f;
+
+        [Header("Confidence Readout")]
+        [SerializeField] private bool _logConfidenceToConsole = false;
+
+        // ── State ─────────────────────────────────────────────────────────
+
+        private EyeTrackingManager _manager;
+        private GameObject         _hitIndicator;
+        private Renderer           _hitRenderer;
+        private Material           _hitMaterial;
+
+        // ── Lifecycle ────────────────────────────────────────────────────
+
+        private void Awake()
+        {
+            _manager = GetComponent<EyeTrackingManager>();
+            if (_manager == null)
+                _manager = FindFirstObjectByType<EyeTrackingManager>();
+
+            if (_manager == null)
+                Debug.LogWarning("[GazeDebug] No EyeTrackingManager found -- debug will use camera forward.");
+
+            if (_showHitIndicator)
+                BuildHitIndicator();
+        }
+
+        private void OnDestroy()
+        {
+            if (_hitIndicator != null) Destroy(_hitIndicator);
+            if (_hitMaterial  != null) Destroy(_hitMaterial);
+        }
+
+        private void Update()
+        {
+            DrawRays();
+            UpdateHitIndicator();
+
+            if (_logConfidenceToConsole && _manager != null)
+                Debug.Log($"[GazeDebug] Confidence: {_manager.GetGazeConfidence():F2}");
+        }
+
+        // ── Ray drawing ──────────────────────────────────────────────────
+
+        private void DrawRays()
+        {
+            float confidence = _manager != null ? _manager.GetGazeConfidence() : 0f;
+            bool hasConfidence = _manager != null && confidence > 0.3f;
+
+#if HAS_META_XR
+            if (_showLeftEye && _manager != null)
+            {
+                Ray leftRay = _manager.GetGazeDirection(GazeEye.Left);
+                Color c = hasConfidence ? _leftEyeColor : _lowConfColor;
+                Debug.DrawRay(leftRay.origin, leftRay.direction * _rayLength, c);
+            }
+
+            if (_showRightEye && _manager != null)
+            {
+                Ray rightRay = _manager.GetGazeDirection(GazeEye.Right);
+                Color c = hasConfidence ? _rightEyeColor : _lowConfColor;
+                Debug.DrawRay(rightRay.origin, rightRay.direction * _rayLength, c);
+            }
+#endif
+
+            if (_showCombined)
+            {
+                Ray combinedRay = _manager != null
+                    ? _manager.GetGazeDirection(GazeEye.Center)
+                    : new Ray(Camera.main != null ? Camera.main.transform.position : Vector3.zero,
+                              Camera.main != null ? Camera.main.transform.forward  : Vector3.forward);
+
+                Color c = hasConfidence ? _combinedColor : _lowConfColor;
+                Debug.DrawRay(combinedRay.origin, combinedRay.direction * _rayLength, c);
+            }
+        }
+
+        // ── Hit indicator ────────────────────────────────────────────────
+
+        private void UpdateHitIndicator()
+        {
+            if (!_showHitIndicator || _hitIndicator == null) return;
+
+            Ray gazeRay = _manager != null
+                ? _manager.GetGazeDirection(GazeEye.Center)
+                : new Ray(Camera.main != null ? Camera.main.transform.position : Vector3.zero,
+                          Camera.main != null ? Camera.main.transform.forward  : Vector3.forward);
+
+            bool hit = Physics.Raycast(gazeRay, out RaycastHit hitInfo, _rayLength * 3f, _hitLayers);
+
+            if (hit)
+            {
+                _hitIndicator.SetActive(true);
+                _hitIndicator.transform.position = hitInfo.point;
+
+                // Color by confidence
+                float conf = _manager != null ? _manager.GetGazeConfidence() : 0f;
+                Color indicatorColor = Color.Lerp(_lowConfColor, _combinedColor, conf);
+                if (_hitMaterial != null) _hitMaterial.color = indicatorColor;
+            }
+            else
+            {
+                // Place at end of ray when no geometry hit
+                _hitIndicator.SetActive(true);
+                _hitIndicator.transform.position = gazeRay.origin + gazeRay.direction * _rayLength;
+                if (_hitMaterial != null) _hitMaterial.color = _lowConfColor;
+            }
+        }
+
+        private void BuildHitIndicator()
+        {
+            _hitIndicator = GameObject.CreatePrimitive(PrimitiveType.Sphere);
+            _hitIndicator.name = "GazeHitIndicator";
+            _hitIndicator.transform.localScale = Vector3.one * _hitSphereRadius * 2f;
+
+            // Remove collider so it does not interfere with gaze raycasts
+            var col = _hitIndicator.GetComponent<Collider>();
+            if (col != null) Destroy(col);
+
+            DontDestroyOnLoad(_hitIndicator);
+
+            var meshRenderer = _hitIndicator.GetComponent<MeshRenderer>();
+            if (meshRenderer != null)
+            {
+                _hitMaterial = new Material(Shader.Find("Universal Render Pipeline/Lit") ??
+                                            Shader.Find("Standard"));
+                _hitMaterial.color = _combinedColor;
+                // Make unlit-ish for clarity
+                _hitMaterial.SetFloat("_Smoothness", 0f);
+                meshRenderer.material = _hitMaterial;
+            }
+        }
+
+        // ── Gizmos ───────────────────────────────────────────────────────
+
+#if UNITY_EDITOR
+        private void OnDrawGizmos()
+        {
+            if (_manager == null) return;
+
+            Ray combined = _manager.GetGazeDirection(GazeEye.Center);
+            float conf   = _manager.GetGazeConfidence();
+
+            UnityEditor.Handles.color = Color.Lerp(_lowConfColor, _combinedColor, conf);
+            UnityEditor.Handles.DrawLine(
+                combined.origin,
+                combined.origin + combined.direction * _rayLength);
+
+            UnityEditor.Handles.color = new Color(_combinedColor.r, _combinedColor.g, _combinedColor.b, 0.2f);
+            UnityEditor.Handles.SphereHandleCap(
+                0,
+                combined.origin + combined.direction * _rayLength,
+                Quaternion.identity,
+                _hitSphereRadius,
+                EventType.Repaint);
+        }
+#endif
+    }
+}

--- a/Assets/Scripts/EyeTracking/GazeInteractable.cs
+++ b/Assets/Scripts/EyeTracking/GazeInteractable.cs
@@ -1,0 +1,214 @@
+// GazeInteractable.cs
+// PLAGA '44 -- Component for objects that react to player gaze.
+// Fires OnGazeEnter / OnGazeExit / OnGazeDwell(duration) events.
+//
+// Usage: Add to any GameObject. The GazeInteractableRegistry polls all
+//        active instances each frame via EyeTrackingManager.
+// Namespace: Plaga44.EyeTracking
+
+using UnityEngine;
+using UnityEngine.Events;
+
+namespace Plaga44.EyeTracking
+{
+    /// <summary>
+    /// Attach to any object that should respond to player gaze.
+    /// Requires an EyeTrackingManager in the scene.
+    /// </summary>
+    public class GazeInteractable : MonoBehaviour
+    {
+        // ── Inspector ─────────────────────────────────────────────────────
+
+        [Header("Gaze Settings")]
+        [Tooltip("Time in seconds the player must look at this object before OnGazeDwell fires.")]
+        [SerializeField] private float _dwellTime = 2f;
+
+        [Tooltip("Angular radius (degrees) within which the gaze is considered 'on' this object. " +
+                 "Overrides distance-based checks when > 0.")]
+        [SerializeField][Range(0f, 30f)] private float _gazeAngleRadius = 3f;
+
+        [Tooltip("If > 0, use sphere-cast distance instead of angular check. " +
+                 "Useful for objects at varying depths.")]
+        [SerializeField][Min(0f)] private float _gazeRadius = 0f;
+
+        [Header("Events")]
+        [SerializeField] private UnityEvent _onGazeEnter  = new UnityEvent();
+        [SerializeField] private UnityEvent _onGazeExit   = new UnityEvent();
+        [SerializeField] private GazeDwellEvent _onGazeDwell = new GazeDwellEvent();
+
+        // ── State ─────────────────────────────────────────────────────────
+
+        private bool  _isGazed     = false;
+        private float _gazeTimer   = 0f;
+        private bool  _dwellFired  = false;
+
+        private EyeTrackingManager _manager;
+
+        // ── Public accessors ─────────────────────────────────────────────
+
+        public bool   IsGazed        => _isGazed;
+        public float  GazeTimer      => _gazeTimer;
+        public float  DwellTime      { get => _dwellTime;       set => _dwellTime       = value; }
+        public float  GazeAngleRadius{ get => _gazeAngleRadius; set => _gazeAngleRadius = value; }
+        public float  GazeRadius     { get => _gazeRadius;      set => _gazeRadius      = value; }
+
+        public UnityEvent OnGazeEnterEvent  => _onGazeEnter;
+        public UnityEvent OnGazeExitEvent   => _onGazeExit;
+        public GazeDwellEvent OnGazeDwellEvent => _onGazeDwell;
+
+        // ── Lifecycle ────────────────────────────────────────────────────
+
+        private void OnEnable()
+        {
+            GazeInteractableRegistry.Register(this);
+        }
+
+        private void OnDisable()
+        {
+            GazeInteractableRegistry.Unregister(this);
+            if (_isGazed) ForceExit();
+        }
+
+        private void Start()
+        {
+            _manager = FindFirstObjectByType<EyeTrackingManager>();
+            if (_manager == null)
+                Debug.LogWarning($"[GazeInteractable] No EyeTrackingManager found in scene. " +
+                                 $"Object '{name}' will not receive gaze events.");
+        }
+
+        // ── Called by GazeInteractableRegistry ──────────────────────────
+
+        /// <summary>
+        /// Evaluate gaze state for this frame. Called externally by the registry.
+        /// </summary>
+        internal void Tick(float deltaTime)
+        {
+            if (_manager == null) return;
+
+            bool currentlyGazed = CheckGaze();
+
+            if (currentlyGazed && !_isGazed)
+            {
+                _isGazed   = true;
+                _gazeTimer = 0f;
+                _dwellFired = false;
+                _onGazeEnter.Invoke();
+            }
+            else if (!currentlyGazed && _isGazed)
+            {
+                ForceExit();
+            }
+
+            if (_isGazed)
+            {
+                _gazeTimer += deltaTime;
+                if (!_dwellFired && _gazeTimer >= _dwellTime)
+                {
+                    _dwellFired = true;
+                    _onGazeDwell.Invoke(_gazeTimer);
+                }
+            }
+        }
+
+        // ── Internal helpers ─────────────────────────────────────────────
+
+        private bool CheckGaze()
+        {
+            if (_manager == null || !_manager.IsEyeTrackingAvailable)
+            {
+                // Fallback: use angular check from camera when tracking unavailable
+                var cam = Camera.main;
+                if (cam == null) return false;
+                var fallbackRay = new Ray(cam.transform.position, cam.transform.forward);
+                return IsRayOnThis(fallbackRay);
+            }
+
+            Ray gazeRay = _manager.GetGazeDirection(GazeEye.Center);
+            return IsRayOnThis(gazeRay);
+        }
+
+        private bool IsRayOnThis(Ray ray)
+        {
+            if (_gazeRadius > 0f)
+            {
+                // Sphere-cast against this object's bounds / collider
+                var col = GetComponent<Collider>();
+                if (col != null)
+                {
+                    return col.bounds.IntersectRay(ray);
+                }
+            }
+
+            // Angular check: angle between gaze ray and direction to object center
+            Vector3 toObject = (transform.position - ray.origin).normalized;
+            float angle = Vector3.Angle(ray.direction, toObject);
+            return angle <= _gazeAngleRadius;
+        }
+
+        private void ForceExit()
+        {
+            _isGazed    = false;
+            _gazeTimer  = 0f;
+            _dwellFired = false;
+            _onGazeExit.Invoke();
+        }
+    }
+
+    // ── Helper types ─────────────────────────────────────────────────────
+
+    /// <summary>UnityEvent that passes the dwell duration as a float parameter.</summary>
+    [System.Serializable]
+    public class GazeDwellEvent : UnityEvent<float> { }
+
+    /// <summary>
+    /// Static registry so GazeInteractable instances can self-register
+    /// and be polled each frame without a manager dependency.
+    /// </summary>
+    public static class GazeInteractableRegistry
+    {
+        private static readonly System.Collections.Generic.List<GazeInteractable> _instances
+            = new System.Collections.Generic.List<GazeInteractable>();
+
+        private static GazeInteractableTicker _ticker;
+
+        public static void Register(GazeInteractable interactable)
+        {
+            if (!_instances.Contains(interactable))
+                _instances.Add(interactable);
+
+            EnsureTicker();
+        }
+
+        public static void Unregister(GazeInteractable interactable)
+        {
+            _instances.Remove(interactable);
+        }
+
+        internal static void TickAll(float deltaTime)
+        {
+            for (int i = _instances.Count - 1; i >= 0; i--)
+            {
+                if (_instances[i] == null) { _instances.RemoveAt(i); continue; }
+                _instances[i].Tick(deltaTime);
+            }
+        }
+
+        private static void EnsureTicker()
+        {
+            if (_ticker != null) return;
+            var go = new GameObject("GazeInteractableRegistry");
+            Object.DontDestroyOnLoad(go);
+            _ticker = go.AddComponent<GazeInteractableTicker>();
+        }
+    }
+
+    /// <summary>
+    /// Hidden MonoBehaviour that drives GazeInteractableRegistry.TickAll each frame.
+    /// Created automatically when the first GazeInteractable registers.
+    /// </summary>
+    internal class GazeInteractableTicker : MonoBehaviour
+    {
+        private void Update() => GazeInteractableRegistry.TickAll(Time.deltaTime);
+    }
+}

--- a/Assets/Scripts/EyeTracking/PeripheralThreat.cs
+++ b/Assets/Scripts/EyeTracking/PeripheralThreat.cs
@@ -1,0 +1,293 @@
+// PeripheralThreat.cs
+// PLAGA '44 -- Horror gameplay mechanic.
+// The threat moves ONLY when it is in peripheral vision.
+// When the player looks directly at it, it freezes completely.
+//
+// Peripheral zone = gaze angle > _directGazeAngle (default 15 deg).
+// The object re-activates movement as soon as the player looks away.
+//
+// Namespace: Plaga44.EyeTracking
+
+using System.Collections;
+using UnityEngine;
+
+namespace Plaga44.EyeTracking
+{
+    /// <summary>
+    /// Attach to a horror entity. It stalks the player in peripheral vision
+    /// but freezes instantly when looked at directly.
+    /// </summary>
+    [RequireComponent(typeof(Rigidbody))]
+    public class PeripheralThreat : MonoBehaviour
+    {
+        // ── Inspector ─────────────────────────────────────────────────────
+
+        [Header("Gaze Thresholds")]
+        [Tooltip("Angle (degrees) from gaze center within which the threat is considered 'directly looked at'.")]
+        [SerializeField][Range(1f, 45f)] private float _directGazeAngle = 15f;
+
+        [Tooltip("When eye tracking is unavailable, use this angle for camera-forward fallback.")]
+        [SerializeField][Range(1f, 45f)] private float _fallbackGazeAngle = 20f;
+
+        [Tooltip("Hysteresis: extra degrees added before resuming movement after a direct gaze. " +
+                 "Prevents flicker at the boundary.")]
+        [SerializeField][Range(0f, 15f)] private float _hysteresisAngle = 5f;
+
+        [Header("Movement")]
+        [Tooltip("Target to move toward (usually the player / camera root).")]
+        [SerializeField] private Transform _target;
+
+        [Tooltip("Movement speed when in peripheral vision.")]
+        [SerializeField][Range(0f, 20f)] private float _moveSpeed = 1.2f;
+
+        [Tooltip("Acceleration applied to Rigidbody (ForceMode.Acceleration).")]
+        [SerializeField] private bool _usePhysicsMovement = false;
+
+        [Tooltip("How quickly the threat can rotate to face the target.")]
+        [SerializeField][Range(0f, 720f)] private float _turnSpeed = 120f;
+
+        [Header("Freeze Behaviour")]
+        [Tooltip("Instantly snap velocity to zero when frozen.")]
+        [SerializeField] private bool _snapVelocityOnFreeze = true;
+
+        [Tooltip("Optional Animator trigger name to fire when the threat freezes.")]
+        [SerializeField] private string _freezeAnimTrigger = "Freeze";
+
+        [Tooltip("Optional Animator trigger name to fire when movement resumes.")]
+        [SerializeField] private string _resumeAnimTrigger = "Resume";
+
+        [Header("Audio")]
+        [Tooltip("Sound played when the threat freezes (player looks at it).")]
+        [SerializeField] private AudioClip _freezeSound;
+
+        [Tooltip("Sound played when movement resumes (player looks away).")]
+        [SerializeField] private AudioClip _resumeSound;
+
+        [Header("Debug")]
+        [SerializeField] private bool _drawDebugGizmos = true;
+
+        // ── State ─────────────────────────────────────────────────────────
+
+        private EyeTrackingManager _manager;
+        private Rigidbody          _rigidbody;
+        private Animator           _animator;
+        private AudioSource        _audio;
+
+        private bool _isFrozen = false;
+        private bool _wasDirectlyGazed = false;
+
+        // ── Events ───────────────────────────────────────────────────────
+
+        /// <summary>Fired when the player directly gazes at the threat (it freezes).</summary>
+        public System.Action OnFreeze;
+
+        /// <summary>Fired when the player looks away and the threat resumes moving.</summary>
+        public System.Action OnResume;
+
+        // ── Lifecycle ────────────────────────────────────────────────────
+
+        private void Awake()
+        {
+            _rigidbody = GetComponent<Rigidbody>();
+            _animator  = GetComponent<Animator>();
+            _audio     = GetComponent<AudioSource>();
+
+            _rigidbody.useGravity  = false;
+            _rigidbody.constraints = RigidbodyConstraints.FreezeRotation;
+
+            // Auto-find target if not set
+            if (_target == null)
+            {
+#if HAS_META_XR
+                var rig = FindFirstObjectByType<OVRCameraRig>();
+                if (rig != null) { _target = rig.centerEyeAnchor; }
+#endif
+                if (_target == null && Camera.main != null)
+                    _target = Camera.main.transform;
+            }
+        }
+
+        private void Start()
+        {
+            _manager = FindFirstObjectByType<EyeTrackingManager>();
+
+            if (_manager == null)
+                Debug.LogWarning($"[PeripheralThreat] '{name}': No EyeTrackingManager -- " +
+                                 "falling back to camera forward for gaze detection.");
+        }
+
+        private void FixedUpdate()
+        {
+            if (_isFrozen || _target == null) return;
+
+            if (_usePhysicsMovement)
+                MovePhysics();
+            else
+                MoveKinematic();
+        }
+
+        private void Update()
+        {
+            bool directlyGazed = CheckDirectGaze();
+
+            // Rising edge: player STARTS looking at threat
+            if (directlyGazed && !_wasDirectlyGazed)
+            {
+                _wasDirectlyGazed = true;
+                Freeze();
+            }
+            // Falling edge: apply hysteresis -- only unfreeze when gaze moves far enough away
+            else if (_wasDirectlyGazed && !directlyGazed)
+            {
+                bool stilTooClose = CheckDirectGaze(_directGazeAngle + _hysteresisAngle);
+                if (!stilTooClose)
+                {
+                    _wasDirectlyGazed = false;
+                    Unfreeze();
+                }
+            }
+        }
+
+        // ── Freeze / Unfreeze ────────────────────────────────────────────
+
+        private void Freeze()
+        {
+            if (_isFrozen) return;
+            _isFrozen = true;
+
+            if (_snapVelocityOnFreeze)
+                _rigidbody.linearVelocity = Vector3.zero;
+
+            if (_animator != null && !string.IsNullOrEmpty(_freezeAnimTrigger))
+                _animator.SetTrigger(_freezeAnimTrigger);
+
+            PlaySound(_freezeSound);
+            OnFreeze?.Invoke();
+        }
+
+        private void Unfreeze()
+        {
+            if (!_isFrozen) return;
+            _isFrozen = false;
+
+            if (_animator != null && !string.IsNullOrEmpty(_resumeAnimTrigger))
+                _animator.SetTrigger(_resumeAnimTrigger);
+
+            PlaySound(_resumeSound);
+            OnResume?.Invoke();
+        }
+
+        // ── Movement ─────────────────────────────────────────────────────
+
+        private void MoveKinematic()
+        {
+            Vector3 toTarget = (_target.position - transform.position);
+            Vector3 dir      = toTarget.normalized;
+
+            // Rotate toward target
+            if (toTarget.sqrMagnitude > 0.01f)
+            {
+                Quaternion lookRot = Quaternion.LookRotation(dir);
+                transform.rotation = Quaternion.RotateTowards(
+                    transform.rotation, lookRot, _turnSpeed * Time.deltaTime);
+            }
+
+            // Move
+            _rigidbody.MovePosition(transform.position + dir * _moveSpeed * Time.fixedDeltaTime);
+        }
+
+        private void MovePhysics()
+        {
+            Vector3 toTarget = (_target.position - transform.position).normalized;
+            _rigidbody.AddForce(toTarget * _moveSpeed, ForceMode.Acceleration);
+
+            // Rotate toward target
+            if (toTarget.sqrMagnitude > 0.01f)
+            {
+                Quaternion lookRot = Quaternion.LookRotation(toTarget);
+                transform.rotation = Quaternion.RotateTowards(
+                    transform.rotation, lookRot, _turnSpeed * Time.deltaTime);
+            }
+        }
+
+        // ── Gaze check ───────────────────────────────────────────────────
+
+        /// <summary>
+        /// Returns true if this threat is within the direct gaze cone.
+        /// </summary>
+        private bool CheckDirectGaze(float overrideAngle = -1f)
+        {
+            float threshold = overrideAngle >= 0f ? overrideAngle : _directGazeAngle;
+
+            Ray gazeRay;
+
+            if (_manager != null)
+            {
+                gazeRay = _manager.GetGazeDirection(GazeEye.Center);
+
+                // If confidence is too low, use fallback angle (wider cone, safer for horror)
+                float conf = _manager.GetGazeConfidence();
+                if (conf < 0.4f)
+                    threshold = overrideAngle >= 0f ? overrideAngle : _fallbackGazeAngle;
+            }
+            else
+            {
+                // Fallback: camera forward
+                var cam = Camera.main;
+                if (cam == null) return false;
+                gazeRay   = new Ray(cam.transform.position, cam.transform.forward);
+                threshold = overrideAngle >= 0f ? overrideAngle : _fallbackGazeAngle;
+            }
+
+            Vector3 toSelf = (transform.position - gazeRay.origin).normalized;
+            float   angle  = Vector3.Angle(gazeRay.direction, toSelf);
+            return angle <= threshold;
+        }
+
+        // ── Helpers ──────────────────────────────────────────────────────
+
+        private void PlaySound(AudioClip clip)
+        {
+            if (_audio == null || clip == null) return;
+            _audio.PlayOneShot(clip);
+        }
+
+        // ── Gizmos ───────────────────────────────────────────────────────
+
+#if UNITY_EDITOR
+        private void OnDrawGizmosSelected()
+        {
+            if (!_drawDebugGizmos) return;
+
+            // Draw freeze cone from target's perspective
+            Transform cam = _target;
+            if (cam == null) cam = Camera.main != null ? Camera.main.transform : null;
+            if (cam == null) return;
+
+            // Direction from camera to this threat
+            Vector3 toSelf = (transform.position - cam.position).normalized;
+            float   dist   = Vector3.Distance(cam.position, transform.position);
+
+            // Direct gaze cone (red = frozen zone)
+            UnityEditor.Handles.color = _isFrozen
+                ? new Color(1f, 0f, 0f, 0.25f)
+                : new Color(1f, 0.5f, 0f, 0.15f);
+
+            UnityEditor.Handles.DrawSolidArc(
+                cam.position, cam.up,
+                Quaternion.AngleAxis(-_directGazeAngle, cam.up) * cam.forward,
+                _directGazeAngle * 2f, dist);
+
+            // Line to threat
+            Gizmos.color = _isFrozen ? Color.red : Color.yellow;
+            Gizmos.DrawLine(cam.position, transform.position);
+            Gizmos.DrawWireSphere(transform.position, 0.15f);
+
+            // State label
+            UnityEditor.Handles.color = _isFrozen ? Color.red : Color.green;
+            UnityEditor.Handles.Label(transform.position + Vector3.up * 0.3f,
+                _isFrozen ? "FROZEN (direct gaze)" : "MOVING (peripheral)");
+        }
+#endif
+    }
+}


### PR DESCRIPTION
## Summary

- **EyeTrackingManager** -- initializes `OVREyeGaze`, exposes `GetGazeDirection(eye)`, `GetGazeConfidence()`, `IsLookingAt(target, angle)`. Falls back to camera forward when eye tracking unavailable.
- **GazeInteractable** -- `OnGazeEnter` / `OnGazeExit` / `OnGazeDwell(float)` UnityEvents. Self-registers into `GazeInteractableRegistry` (auto-spawns a DontDestroyOnLoad ticker). Configurable `dwellTime` and `gazeAngleRadius`.
- **GazeDebug** -- `Debug.DrawRay` per eye + combined (Scene view), runtime hit-indicator sphere, `OnDrawGizmos` with confidence-colored arc. Toggle per eye in Inspector.
- **PeripheralThreat** -- Rigidbody-based horror entity. Moves toward player only while in peripheral vision (`gaze angle > _directGazeAngle`). Freezes (velocity snap) + fires `OnFreeze` event when directly looked at. Hysteresis prevents flicker at boundary. Supports Animator trigger, AudioClip, Physics or kinematic movement mode.

All OVR calls behind `#if HAS_META_XR`. Namespace `Plaga44.EyeTracking`. No existing files modified.

## Test plan

- [ ] **No Meta XR SDK**: project compiles without errors (all OVR calls excluded by preprocessor)
- [ ] **EyeTrackingManager**: Add to OVRCameraRig root. In Play mode on Quest 3, `GetGazeConfidence()` > 0 and `GetGazeDirection()` tracks eye movement
- [ ] **GazeInteractable**: Add to a cube. Wire `OnGazeEnter` -> Debug.Log. Look at cube -- event fires. Look away -- `OnGazeExit` fires. Hold gaze for `dwellTime` -- `OnGazeDwell` fires with elapsed time
- [ ] **GazeDebug**: Add alongside EyeTrackingManager. Scene view shows colored gaze rays. Game view shows hit sphere on geometry under gaze
- [ ] **PeripheralThreat**: Add to an enemy with Rigidbody. Set Target = Player. Look away -- it moves closer. Look directly at it -- it freezes instantly. Hysteresis: it does not flicker at the boundary angle

closes #32
Closes #32