### PR TITLE
feat: NPC locomotion system -- NavMesh patrol + state machine (#40)

### DIFF
--- a/Assets/Editor/NPCSetup.cs
+++ b/Assets/Editor/NPCSetup.cs
@@ -1,0 +1,166 @@
+#if UNITY_EDITOR
+using UnityEditor;
+using UnityEngine;
+using UnityEngine.AI;
+using Plaga44.NPC;
+
+namespace Plaga44.Editor
+{
+    /// <summary>
+    /// Editor tool: CYBERNOMAD > Scene Setup > Add Test NPC
+    ///
+    /// Creates a capsule NPC with:
+    ///   - NavMeshAgent
+    ///   - NPCLocomotion
+    ///   - NPCStateController
+    ///   - A WaypointPath with 4 patrol points arranged in a square
+    ///   - Simple URP materials (body = warm grey, patrol waypoints = green)
+    /// </summary>
+    public static class NPCSetup
+    {
+        private const string LOG = "[PLAGA44]";
+
+        [MenuItem("CYBERNOMAD/Scene Setup/Add Test NPC", false, 102)]
+        public static void AddTestNPC()
+        {
+            Debug.Log($"{LOG} Creating test NPC...");
+
+            // ----------------------------------------------------------------
+            // Root container
+            // ----------------------------------------------------------------
+            GameObject root = new GameObject("TestNPC");
+            Undo.RegisterCreatedObjectUndo(root, "Create Test NPC");
+
+            // ----------------------------------------------------------------
+            // Visual: Capsule body
+            // ----------------------------------------------------------------
+            GameObject body = GameObject.CreatePrimitive(PrimitiveType.Capsule);
+            body.name = "Body";
+            body.transform.SetParent(root.transform);
+            body.transform.localPosition = new Vector3(0f, 1f, 0f); // capsule pivot is at centre
+            body.transform.localScale    = Vector3.one;
+
+            // Remove the capsule collider -- NavMeshAgent handles movement
+            Object.DestroyImmediate(body.GetComponent<CapsuleCollider>());
+
+            SetMaterial(body, new Color(0.55f, 0.45f, 0.40f)); // warm grey / skin tone
+
+            // Head indicator (small sphere so direction is obvious)
+            GameObject head = GameObject.CreatePrimitive(PrimitiveType.Sphere);
+            head.name = "Head";
+            head.transform.SetParent(root.transform);
+            head.transform.localPosition = new Vector3(0f, 2.2f, 0f);
+            head.transform.localScale    = Vector3.one * 0.4f;
+            Object.DestroyImmediate(head.GetComponent<SphereCollider>());
+            SetMaterial(head, new Color(0.85f, 0.72f, 0.60f)); // lighter skin
+
+            // ----------------------------------------------------------------
+            // NavMeshAgent (on root so it drives root position)
+            // ----------------------------------------------------------------
+            NavMeshAgent agent = root.AddComponent<NavMeshAgent>();
+            agent.height          = 2f;
+            agent.radius          = 0.35f;
+            agent.speed           = 2f;
+            agent.angularSpeed    = 180f;
+            agent.acceleration    = 8f;
+            agent.stoppingDistance = 0.4f;
+            agent.autoBraking     = true;
+
+            // ----------------------------------------------------------------
+            // Waypoint path: 4 points in a square (5m side)
+            // ----------------------------------------------------------------
+            GameObject pathRoot = new GameObject("PatrolPath");
+            pathRoot.transform.SetParent(root.transform);
+            pathRoot.transform.localPosition = Vector3.zero;
+
+            WaypointPath waypointPath = pathRoot.AddComponent<WaypointPath>();
+
+            float half = 2.5f;
+            Vector3[] corners = new Vector3[]
+            {
+                new Vector3( half, 0f,  half),
+                new Vector3(-half, 0f,  half),
+                new Vector3(-half, 0f, -half),
+                new Vector3( half, 0f, -half),
+            };
+
+            Transform[] waypoints = new Transform[corners.Length];
+            for (int i = 0; i < corners.Length; i++)
+            {
+                GameObject wp = new GameObject($"WP_{i:D2}");
+                wp.transform.SetParent(pathRoot.transform);
+                wp.transform.localPosition = corners[i];
+                waypoints[i] = wp.transform;
+            }
+            waypointPath.waypoints = waypoints;
+
+            // ----------------------------------------------------------------
+            // NPCLocomotion
+            // ----------------------------------------------------------------
+            NPCLocomotion locomotion = root.AddComponent<NPCLocomotion>();
+            locomotion.waypointPath         = waypointPath;
+            locomotion.baseSpeed            = 2f;
+            locomotion.waypointReachDistance = 0.5f;
+
+            // ----------------------------------------------------------------
+            // NPCStateController
+            // ----------------------------------------------------------------
+            root.AddComponent<NPCStateController>();
+
+            // ----------------------------------------------------------------
+            // Place in scene: 3 m in front of Scene View camera
+            // ----------------------------------------------------------------
+            root.transform.position = GetSceneViewSpawnPosition();
+
+            // ----------------------------------------------------------------
+            // Select and log
+            // ----------------------------------------------------------------
+            Selection.activeGameObject = root;
+
+            Debug.Log($"{LOG} Test NPC created at {root.transform.position}.");
+            Debug.Log($"{LOG} Next steps:");
+            Debug.Log($"{LOG}   1. Bake a NavMesh (Window > AI > Navigation) or use NavMesh Surface.");
+            Debug.Log($"{LOG}   2. Optionally add an Animator Controller with Speed / VelX / VelZ / IsMoving params.");
+            Debug.Log($"{LOG}   3. Move patrol waypoints to desired positions in the scene.");
+        }
+
+        // ------------------------------------------------------------------ //
+        //  Helpers
+        // ------------------------------------------------------------------ //
+
+        private static void SetMaterial(GameObject obj, Color color)
+        {
+            Renderer rend = obj.GetComponent<Renderer>();
+            if (rend == null) return;
+
+            // Try URP Lit first; fall back to Standard
+            Shader shader = Shader.Find("Universal Render Pipeline/Lit")
+                         ?? Shader.Find("Standard");
+
+            if (shader == null)
+            {
+                Debug.LogWarning($"{LOG} Could not find a valid shader for NPC materials.");
+                return;
+            }
+
+            Material mat = new Material(shader);
+            mat.color = color;
+            rend.sharedMaterial = mat;
+        }
+
+        private static Vector3 GetSceneViewSpawnPosition()
+        {
+            SceneView sv = SceneView.lastActiveSceneView;
+            if (sv == null) return new Vector3(0f, 0f, 3f);
+
+            // Place 5 units in front of the scene camera pivot
+            Vector3 forward = sv.camera.transform.forward;
+            forward.y = 0f;
+            if (forward.sqrMagnitude < 0.001f) forward = Vector3.forward;
+            forward.Normalize();
+
+            return sv.pivot + forward * 5f;
+        }
+    }
+}
+#endif

--- a/Assets/Scripts/NPC/NPCLocomotion.cs
+++ b/Assets/Scripts/NPC/NPCLocomotion.cs
@@ -1,0 +1,203 @@
+using UnityEngine;
+using UnityEngine.AI;
+
+namespace Plaga44.NPC
+{
+    /// <summary>
+    /// Core NPC locomotion controller.
+    /// Drives a NavMeshAgent along a WaypointPath and feeds an Animator with
+    /// motion parameters (speed, velocity direction) ready for future integration
+    /// with Meta Movement SDK / AI Motion Synthesizer.
+    ///
+    /// Animator parameter contract (all optional -- missing params are silently ignored):
+    ///   float "Speed"     -- normalised agent speed [0..1]
+    ///   float "VelX"      -- local velocity X (strafe, for blendtrees)
+    ///   float "VelZ"      -- local velocity Z (forward, for blendtrees)
+    ///   bool  "IsMoving"  -- true when agent has a destination and is moving
+    /// </summary>
+    [RequireComponent(typeof(NavMeshAgent))]
+    public class NPCLocomotion : MonoBehaviour
+    {
+        // ------------------------------------------------------------------ //
+        //  Inspector
+        // ------------------------------------------------------------------ //
+
+        [Header("Navigation")]
+        [Tooltip("Patrol path. Assign a WaypointPath in the scene.")]
+        public WaypointPath waypointPath;
+
+        [Tooltip("Base movement speed (m/s). State multipliers are applied on top.")]
+        [Min(0.1f)]
+        public float baseSpeed = 2f;
+
+        [Tooltip("How close the agent needs to be to a waypoint before moving to the next.")]
+        [Min(0.05f)]
+        public float waypointReachDistance = 0.5f;
+
+        [Header("Animator")]
+        [Tooltip("Animator to drive. If null, auto-resolved from this GameObject.")]
+        public Animator animator;
+
+        [Tooltip("Smoothing time for Animator float parameters.")]
+        [Min(0f)]
+        public float animatorDampTime = 0.1f;
+
+        // ------------------------------------------------------------------ //
+        //  Animator parameter hashes (cached for perf)
+        // ------------------------------------------------------------------ //
+
+        private static readonly int HashSpeed    = Animator.StringToHash("Speed");
+        private static readonly int HashVelX     = Animator.StringToHash("VelX");
+        private static readonly int HashVelZ     = Animator.StringToHash("VelZ");
+        private static readonly int HashIsMoving = Animator.StringToHash("IsMoving");
+
+        // ------------------------------------------------------------------ //
+        //  Runtime state
+        // ------------------------------------------------------------------ //
+
+        private NavMeshAgent _agent;
+        private int _currentWaypointIndex;
+        private float _speedMultiplier = 1f;
+
+        // ------------------------------------------------------------------ //
+        //  Unity lifecycle
+        // ------------------------------------------------------------------ //
+
+        private void Awake()
+        {
+            _agent = GetComponent<NavMeshAgent>();
+
+            if (animator == null)
+                animator = GetComponent<Animator>();
+        }
+
+        private void Start()
+        {
+            _agent.speed = baseSpeed * _speedMultiplier;
+            MoveToNextWaypoint();
+        }
+
+        private void Update()
+        {
+            UpdatePatrol();
+            UpdateAnimator();
+        }
+
+        // ------------------------------------------------------------------ //
+        //  Public API
+        // ------------------------------------------------------------------ //
+
+        /// <summary>
+        /// Adjusts agent speed by multiplier.
+        /// Called by NPCStateController when state changes.
+        /// </summary>
+        public void SetSpeedMultiplier(float multiplier)
+        {
+            _speedMultiplier = Mathf.Max(0f, multiplier);
+            _agent.speed = baseSpeed * _speedMultiplier;
+
+            if (_speedMultiplier <= 0f)
+                _agent.ResetPath();
+            else if (!_agent.hasPath && waypointPath != null && waypointPath.Count > 0)
+                MoveToNextWaypoint();
+        }
+
+        /// <summary>
+        /// Immediately navigates to an arbitrary world position.
+        /// Used by NPCStateController in Chase / Alert states.
+        /// </summary>
+        public void NavigateTo(Vector3 worldPosition)
+        {
+            if (!_agent.isOnNavMesh) return;
+            _agent.SetDestination(worldPosition);
+        }
+
+        /// <summary>Stops the agent and clears its path.</summary>
+        public void StopNavigation()
+        {
+            if (_agent.isOnNavMesh)
+                _agent.ResetPath();
+        }
+
+        // ------------------------------------------------------------------ //
+        //  Patrol logic
+        // ------------------------------------------------------------------ //
+
+        private void UpdatePatrol()
+        {
+            if (waypointPath == null || waypointPath.Count == 0) return;
+            if (!_agent.isOnNavMesh) return;
+            if (_agent.pathPending) return;
+            if (_speedMultiplier <= 0f) return;
+
+            // Check if close enough to current waypoint
+            float dist = Vector3.Distance(transform.position, waypointPath.GetPosition(_currentWaypointIndex));
+            if (dist <= waypointReachDistance || (_agent.remainingDistance <= waypointReachDistance && !_agent.pathPending))
+            {
+                _currentWaypointIndex = waypointPath.NextIndex(_currentWaypointIndex);
+                MoveToNextWaypoint();
+            }
+        }
+
+        private void MoveToNextWaypoint()
+        {
+            if (waypointPath == null || waypointPath.Count == 0) return;
+            if (!_agent.isOnNavMesh) return;
+            if (_speedMultiplier <= 0f) return;
+
+            Vector3 target = waypointPath.GetPosition(_currentWaypointIndex);
+            _agent.SetDestination(target);
+        }
+
+        // ------------------------------------------------------------------ //
+        //  Animator bridge
+        // ------------------------------------------------------------------ //
+
+        private void UpdateAnimator()
+        {
+            if (animator == null) return;
+
+            float agentMaxSpeed = _agent.speed > 0f ? _agent.speed : 1f;
+            float normSpeed     = _agent.velocity.magnitude / agentMaxSpeed;
+            bool  isMoving      = normSpeed > 0.05f;
+
+            // Local velocity for directional blendtrees
+            Vector3 localVel = transform.InverseTransformDirection(_agent.velocity);
+            float normVelX   = agentMaxSpeed > 0f ? localVel.x / agentMaxSpeed : 0f;
+            float normVelZ   = agentMaxSpeed > 0f ? localVel.z / agentMaxSpeed : 0f;
+
+            // Use damp time for smooth transitions; check param existence via try-approach
+            TrySetFloat(HashSpeed,    normSpeed, animatorDampTime);
+            TrySetFloat(HashVelX,     normVelX,  animatorDampTime);
+            TrySetFloat(HashVelZ,     normVelZ,  animatorDampTime);
+            TrySetBool(HashIsMoving,  isMoving);
+        }
+
+        // Safe wrappers -- Unity 6 throws if param doesn't exist in controller
+        private void TrySetFloat(int hash, float value, float dampTime)
+        {
+            try { animator.SetFloat(hash, value, dampTime, Time.deltaTime); }
+            catch { /* Animator controller doesn't have this parameter -- skip */ }
+        }
+
+        private void TrySetBool(int hash, bool value)
+        {
+            try { animator.SetBool(hash, value); }
+            catch { /* Animator controller doesn't have this parameter -- skip */ }
+        }
+
+        // ------------------------------------------------------------------ //
+        //  Gizmo: show current destination
+        // ------------------------------------------------------------------ //
+
+        private void OnDrawGizmosSelected()
+        {
+            if (_agent == null || !Application.isPlaying) return;
+            if (!_agent.hasPath) return;
+
+            Gizmos.color = Color.yellow;
+            Gizmos.DrawLine(transform.position, _agent.destination);
+            Gizmos.DrawWireSphere(_agent.destination, 0.15f);
+        }
+    }
+}

--- a/Assets/Scripts/NPC/NPCSpawner.cs
+++ b/Assets/Scripts/NPC/NPCSpawner.cs
@@ -1,0 +1,140 @@
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.AI;
+
+namespace Plaga44.NPC
+{
+    /// <summary>
+    /// Instantiates NPC prefabs at runtime within a configurable radius.
+    /// Spawned NPCs are placed on the NavMesh; positions that can't be projected
+    /// are skipped with a warning.
+    ///
+    /// Usage:
+    ///   1. Assign an NPC prefab that has NPCLocomotion (+ NavMeshAgent).
+    ///   2. Optionally assign a shared WaypointPath -- each NPC will reference it.
+    ///   3. Call Spawn() at runtime (or enable spawnOnStart).
+    /// </summary>
+    public class NPCSpawner : MonoBehaviour
+    {
+        // ------------------------------------------------------------------ //
+        //  Inspector
+        // ------------------------------------------------------------------ //
+
+        [Header("Prefab")]
+        [Tooltip("NPC prefab to instantiate. Must have NPCLocomotion.")]
+        public GameObject npcPrefab;
+
+        [Header("Spawn Settings")]
+        [Tooltip("Number of NPCs to spawn.")]
+        [Min(1)]
+        public int spawnCount = 3;
+
+        [Tooltip("Radius around this transform's position within which NPCs are placed.")]
+        [Min(0.5f)]
+        public float spawnRadius = 5f;
+
+        [Tooltip("NavMesh sample distance for projecting random positions onto the mesh.")]
+        [Min(0.1f)]
+        public float navMeshSampleDistance = 2f;
+
+        [Tooltip("Spawn automatically when the scene starts.")]
+        public bool spawnOnStart = true;
+
+        [Header("Patrol Path")]
+        [Tooltip("Optional shared WaypointPath assigned to every spawned NPC.")]
+        public WaypointPath sharedWaypointPath;
+
+        [Header("Parent")]
+        [Tooltip("Optional parent Transform for spawned NPCs. Keeps hierarchy clean.")]
+        public Transform spawnParent;
+
+        // ------------------------------------------------------------------ //
+        //  Runtime state
+        // ------------------------------------------------------------------ //
+
+        private readonly List<GameObject> _spawnedNPCs = new List<GameObject>();
+
+        public IReadOnlyList<GameObject> SpawnedNPCs => _spawnedNPCs;
+
+        // ------------------------------------------------------------------ //
+        //  Unity lifecycle
+        // ------------------------------------------------------------------ //
+
+        private void Start()
+        {
+            if (spawnOnStart)
+                Spawn();
+        }
+
+        // ------------------------------------------------------------------ //
+        //  Public API
+        // ------------------------------------------------------------------ //
+
+        /// <summary>
+        /// Spawns spawnCount NPCs around this transform.
+        /// Existing spawned NPCs are NOT destroyed -- call DespawnAll() first if needed.
+        /// </summary>
+        public void Spawn()
+        {
+            if (npcPrefab == null)
+            {
+                Debug.LogWarning($"[NPCSpawner] {name}: npcPrefab is not assigned. Aborting spawn.");
+                return;
+            }
+
+            int spawned = 0;
+            int maxAttempts = spawnCount * 5; // give up after N attempts per NPC
+
+            for (int attempt = 0; attempt < maxAttempts && spawned < spawnCount; attempt++)
+            {
+                Vector3 candidate = transform.position + (Vector3)(Random.insideUnitCircle * spawnRadius);
+                candidate.y = transform.position.y;
+
+                if (!NavMesh.SamplePosition(candidate, out NavMeshHit hit, navMeshSampleDistance, NavMesh.AllAreas))
+                    continue;
+
+                GameObject npc = Instantiate(npcPrefab, hit.position, Quaternion.Euler(0f, Random.Range(0f, 360f), 0f), spawnParent);
+                npc.name = $"{npcPrefab.name}_{spawned:D2}";
+
+                // Assign shared patrol path if provided
+                if (sharedWaypointPath != null)
+                {
+                    var locomotion = npc.GetComponent<NPCLocomotion>();
+                    if (locomotion != null)
+                        locomotion.waypointPath = sharedWaypointPath;
+                }
+
+                _spawnedNPCs.Add(npc);
+                spawned++;
+            }
+
+            if (spawned < spawnCount)
+                Debug.LogWarning($"[NPCSpawner] {name}: Only {spawned}/{spawnCount} NPCs placed -- not enough valid NavMesh positions within radius {spawnRadius}m.");
+            else
+                Debug.Log($"[NPCSpawner] {name}: Spawned {spawned} NPCs.");
+        }
+
+        /// <summary>Destroys all NPCs created by this spawner.</summary>
+        public void DespawnAll()
+        {
+            foreach (var npc in _spawnedNPCs)
+            {
+                if (npc != null)
+                    Destroy(npc);
+            }
+            _spawnedNPCs.Clear();
+        }
+
+        // ------------------------------------------------------------------ //
+        //  Gizmo
+        // ------------------------------------------------------------------ //
+
+        private void OnDrawGizmosSelected()
+        {
+            Gizmos.color = new Color(1f, 0.5f, 0f, 0.3f);
+            Gizmos.DrawSphere(transform.position, spawnRadius);
+            Gizmos.color = new Color(1f, 0.5f, 0f, 0.8f);
+            Gizmos.DrawWireSphere(transform.position, spawnRadius);
+        }
+    }
+}

--- a/Assets/Scripts/NPC/NPCStateController.cs
+++ b/Assets/Scripts/NPC/NPCStateController.cs
@@ -1,0 +1,184 @@
+using System;
+using UnityEngine;
+
+namespace Plaga44.NPC
+{
+    /// <summary>
+    /// NPC behavioural states used by NPCLocomotion and future AI systems.
+    /// </summary>
+    public enum NPCState
+    {
+        Idle,
+        Patrol,
+        Alert,
+        Chase,
+        Dead
+    }
+
+    /// <summary>
+    /// Manages NPC state transitions and exposes per-state configuration
+    /// (speed multiplier, Animator parameter names).
+    /// Raises OnStateChanged whenever the active state changes.
+    /// </summary>
+    [RequireComponent(typeof(NPCLocomotion))]
+    public class NPCStateController : MonoBehaviour
+    {
+        // ------------------------------------------------------------------ //
+        //  Per-state configuration
+        // ------------------------------------------------------------------ //
+
+        [Serializable]
+        public class StateConfig
+        {
+            public NPCState state;
+
+            [Tooltip("NavMeshAgent speed multiplier relative to NPCLocomotion.baseSpeed.")]
+            [Min(0f)]
+            public float speedMultiplier = 1f;
+
+            [Tooltip("Animator bool/trigger parameter to set when entering this state. Leave empty to skip.")]
+            public string animatorParam = "";
+
+            [Tooltip("If true, animatorParam is treated as a Trigger; otherwise as a Bool.")]
+            public bool isTrigger = false;
+        }
+
+        [Header("State Configuration")]
+        [SerializeField]
+        private StateConfig[] stateConfigs = new StateConfig[]
+        {
+            new StateConfig { state = NPCState.Idle,   speedMultiplier = 0f,  animatorParam = "IsMoving", isTrigger = false },
+            new StateConfig { state = NPCState.Patrol, speedMultiplier = 1f,  animatorParam = "IsMoving", isTrigger = false },
+            new StateConfig { state = NPCState.Alert,  speedMultiplier = 0.6f, animatorParam = "IsAlert",  isTrigger = false },
+            new StateConfig { state = NPCState.Chase,  speedMultiplier = 2f,  animatorParam = "IsChasing", isTrigger = false },
+            new StateConfig { state = NPCState.Dead,   speedMultiplier = 0f,  animatorParam = "Die",       isTrigger = true  },
+        };
+
+        [Header("Transitions")]
+        [Tooltip("Delay in seconds before transitioning from Alert back to Patrol when no threat is detected.")]
+        [Min(0f)]
+        public float alertCooldown = 5f;
+
+        // ------------------------------------------------------------------ //
+        //  Events
+        // ------------------------------------------------------------------ //
+
+        /// <summary>
+        /// Fired when the NPC transitions to a new state.
+        /// Arguments: previousState, newState.
+        /// </summary>
+        public event Action<NPCState, NPCState> OnStateChanged;
+
+        // ------------------------------------------------------------------ //
+        //  State
+        // ------------------------------------------------------------------ //
+
+        public NPCState CurrentState { get; private set; } = NPCState.Idle;
+
+        private NPCLocomotion _locomotion;
+        private Animator _animator;
+        private float _alertTimer;
+
+        // ------------------------------------------------------------------ //
+        //  Unity lifecycle
+        // ------------------------------------------------------------------ //
+
+        private void Awake()
+        {
+            _locomotion = GetComponent<NPCLocomotion>();
+            _animator   = GetComponent<Animator>();
+        }
+
+        private void Start()
+        {
+            // Apply initial state without firing the event
+            ApplyConfig(CurrentState);
+        }
+
+        private void Update()
+        {
+            // Auto-reset Alert -> Patrol after cooldown
+            if (CurrentState == NPCState.Alert)
+            {
+                _alertTimer -= Time.deltaTime;
+                if (_alertTimer <= 0f)
+                    SetState(NPCState.Patrol);
+            }
+        }
+
+        // ------------------------------------------------------------------ //
+        //  Public API
+        // ------------------------------------------------------------------ //
+
+        /// <summary>Transition to newState. No-op if already in that state.</summary>
+        public void SetState(NPCState newState)
+        {
+            if (newState == CurrentState) return;
+            if (CurrentState == NPCState.Dead) return; // dead is terminal
+
+            NPCState previous = CurrentState;
+            CurrentState = newState;
+
+            if (newState == NPCState.Alert)
+                _alertTimer = alertCooldown;
+
+            ApplyConfig(newState);
+            OnStateChanged?.Invoke(previous, newState);
+
+            Debug.Log($"[NPC] {name}: {previous} -> {newState}");
+        }
+
+        /// <summary>Convenience helper: puts NPC into Alert state and starts cooldown timer.</summary>
+        public void TriggerAlert()  => SetState(NPCState.Alert);
+
+        /// <summary>Convenience helper: puts NPC into Chase state.</summary>
+        public void TriggerChase()  => SetState(NPCState.Chase);
+
+        /// <summary>Kills the NPC (terminal state).</summary>
+        public void Die()           => SetState(NPCState.Dead);
+
+        // ------------------------------------------------------------------ //
+        //  Internal helpers
+        // ------------------------------------------------------------------ //
+
+        private void ApplyConfig(NPCState targetState)
+        {
+            StateConfig cfg = GetConfig(targetState);
+            if (cfg == null) return;
+
+            // Update locomotion speed
+            if (_locomotion != null)
+                _locomotion.SetSpeedMultiplier(cfg.speedMultiplier);
+
+            // Update animator
+            if (_animator != null && !string.IsNullOrEmpty(cfg.animatorParam))
+            {
+                if (cfg.isTrigger)
+                {
+                    _animator.SetTrigger(cfg.animatorParam);
+                }
+                else
+                {
+                    // For bool params: set all non-trigger params to false, then enable the active one.
+                    // This ensures bools from previous states are cleared.
+                    foreach (var c in stateConfigs)
+                    {
+                        if (!c.isTrigger && !string.IsNullOrEmpty(c.animatorParam))
+                            _animator.SetBool(c.animatorParam, false);
+                    }
+                    _animator.SetBool(cfg.animatorParam, true);
+                }
+            }
+        }
+
+        private StateConfig GetConfig(NPCState targetState)
+        {
+            if (stateConfigs == null) return null;
+            foreach (var cfg in stateConfigs)
+            {
+                if (cfg.state == targetState) return cfg;
+            }
+            return null;
+        }
+    }
+}

--- a/Assets/Scripts/NPC/WaypointPath.cs
+++ b/Assets/Scripts/NPC/WaypointPath.cs
@@ -1,0 +1,87 @@
+using UnityEngine;
+
+namespace Plaga44.NPC
+{
+    /// <summary>
+    /// Defines a patrol path as an ordered list of world-space waypoints.
+    /// Draws Gizmos in the editor so the path is visible without Play mode.
+    /// </summary>
+    public class WaypointPath : MonoBehaviour
+    {
+        [Tooltip("Ordered list of waypoints. NPC walks in sequence and loops.")]
+        public Transform[] waypoints = new Transform[0];
+
+        [Tooltip("Draw gizmos even when this GameObject is not selected.")]
+        public bool alwaysDrawGizmos = true;
+
+        [Tooltip("Gizmo sphere radius at each waypoint.")]
+        public float gizmoRadius = 0.2f;
+
+        [Tooltip("Color of the patrol path gizmos.")]
+        public Color gizmoColor = new Color(0f, 1f, 0.4f, 0.8f);
+
+        /// <summary>Returns the number of valid waypoints in the path.</summary>
+        public int Count => waypoints != null ? waypoints.Length : 0;
+
+        /// <summary>
+        /// Returns the world position of waypoint at index.
+        /// Falls back to this transform's position if the waypoint is null.
+        /// </summary>
+        public Vector3 GetPosition(int index)
+        {
+            if (waypoints == null || waypoints.Length == 0)
+                return transform.position;
+
+            index = ((index % waypoints.Length) + waypoints.Length) % waypoints.Length;
+            return waypoints[index] != null ? waypoints[index].position : transform.position;
+        }
+
+        /// <summary>Returns the next waypoint index after wrapping around.</summary>
+        public int NextIndex(int current)
+        {
+            if (waypoints == null || waypoints.Length == 0) return 0;
+            return (current + 1) % waypoints.Length;
+        }
+
+        // ------------------------------------------------------------------ //
+        //  Gizmos
+        // ------------------------------------------------------------------ //
+
+        private void OnDrawGizmos()
+        {
+            if (alwaysDrawGizmos) DrawGizmos();
+        }
+
+        private void OnDrawGizmosSelected()
+        {
+            if (!alwaysDrawGizmos) DrawGizmos();
+        }
+
+        private void DrawGizmos()
+        {
+            if (waypoints == null || waypoints.Length == 0) return;
+
+            Gizmos.color = gizmoColor;
+
+            for (int i = 0; i < waypoints.Length; i++)
+            {
+                if (waypoints[i] == null) continue;
+
+                Vector3 current = waypoints[i].position;
+                Gizmos.DrawSphere(current, gizmoRadius);
+
+#if UNITY_EDITOR
+                UnityEditor.Handles.color = gizmoColor;
+                UnityEditor.Handles.Label(current + Vector3.up * (gizmoRadius + 0.1f), $"[{i}]");
+#endif
+
+                // Draw line to next waypoint
+                int next = (i + 1) % waypoints.Length;
+                if (waypoints[next] != null)
+                {
+                    Gizmos.DrawLine(current, waypoints[next].position);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- **NPCLocomotion** -- NavMeshAgent drives patrol between waypoints; feeds Animator with `Speed`, `VelX`, `VelZ`, `IsMoving` params ready for Meta Movement SDK / AI Motion Synthesizer integration
- **NPCStateController** -- state machine with 5 states (Idle, Patrol, Alert, Chase, Dead); per-state speed multipliers and Animator params; `OnStateChanged` event for external systems
- **WaypointPath** -- ordered `Transform[]` patrol path; draws colored Gizmos + index labels in Scene View
- **NPCSpawner** -- runtime spawner with configurable count, radius, and NavMesh projection; optional shared `WaypointPath` for all spawned NPCs
- **NPCSetup (Editor)** -- `CYBERNOMAD > Scene Setup > Add Test NPC` creates a capsule NPC with 4-waypoint square patrol path, NavMeshAgent pre-configured

Closes #40

## Test plan

### Editor tool
- [ ] Open the Unity testbed scene
- [ ] Menu: `CYBERNOMAD > Scene Setup > Add Test NPC`
- [ ] Verify a `TestNPC` GameObject appears in the Hierarchy with children: `Body`, `Head`, `PatrolPath` (containing `WP_00`..`WP_03`)
- [ ] Verify components on `TestNPC`: `NavMeshAgent`, `NPCLocomotion`, `NPCStateController`
- [ ] Select `PatrolPath` -- verify green gizmos (4 squares + lines) appear in Scene View

### Play mode (requires baked NavMesh)
- [ ] Bake NavMesh (`Window > AI > Navigation > Bake`) on the test scene floor
- [ ] Press Play -- NPC should patrol between the 4 waypoints continuously
- [ ] In Inspector, call `NPCStateController.SetState(Alert)` -- NPC should slow/stop, then return to Patrol after 5 s
- [ ] Call `NPCStateController.Die()` -- NPC should stop permanently

### Spawner
- [ ] Add a `NPCSpawner` component to any GameObject, assign the `TestNPC` prefab, press Play
- [ ] Verify N NPCs spawn within the configured radius on the NavMesh
Closes #40