### PR TITLE
feat: Hip Pinning + IK -- seated posture, crouch & lean detection (#41)

### DIFF
--- a/Assets/Scripts/IK.meta
+++ b/Assets/Scripts/IK.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b403c4c5b2f64de7822d265f0f0531cc
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/IK/CrouchDetector.cs
+++ b/Assets/Scripts/IK/CrouchDetector.cs
@@ -1,0 +1,169 @@
+// CrouchDetector.cs
+// PLAGA '44 -- Detects physical player crouching in real life by tracking
+// the headset Y position relative to a calibrated standing height.
+// Useful for cover mechanics: peek over walls, duck under obstacles.
+//
+// Call Calibrate() after the player stands fully upright to set standing height.
+// Or let the component auto-calibrate on Start using the initial headset height.
+//
+// Namespace: Plaga44.IK
+
+using UnityEngine;
+using UnityEngine.Events;
+
+namespace Plaga44.IK
+{
+    /// <summary>
+    /// Detects physical crouch by comparing real-world headset height
+    /// against a calibrated standing height. Fires OnCrouch/OnStand events.
+    /// </summary>
+    public class CrouchDetector : MonoBehaviour
+    {
+        // ── Inspector ────────────────────────────────────────────────────
+
+        [Header("Headset Reference")]
+        [Tooltip("The CenterEyeAnchor or Camera.main transform. Auto-found if null.")]
+        public Transform headsetTransform;
+
+        [Header("Thresholds")]
+        [Tooltip("Player is considered crouching when headset drops this many metres below standing height.")]
+        [Range(0.05f, 0.6f)]
+        public float crouchThreshold = 0.25f;
+
+        [Tooltip("Hysteresis: player must rise this far above crouchThreshold before OnStand fires. " +
+                 "Prevents rapid toggling when head hovers at threshold.")]
+        [Range(0f, 0.15f)]
+        public float standHysteresis = 0.05f;
+
+        [Header("Calibration")]
+        [Tooltip("Standing height is set to this value on Start if autoCalibrate is false. " +
+                 "Typical range for average adult in headset: 1.55 -- 1.85 m.")]
+        [Range(1.2f, 2.2f)]
+        public float defaultStandingHeight = 1.75f;
+
+        [Tooltip("If true, standing height is read from the headset's Y position on Start. " +
+                 "The player should be standing upright when the scene loads.")]
+        public bool autoCalibrate = true;
+
+        [Header("Events")]
+        [Tooltip("Fired once when the player enters a crouch.")]
+        public UnityEvent OnCrouch;
+
+        [Tooltip("Fired once when the player stands up from a crouch.")]
+        public UnityEvent OnStand;
+
+        [Tooltip("Fired every frame with current crouch depth (0 = standing, 1 = fully crouched to floor).")]
+        public UnityEvent<float> OnCrouchDepthChanged;
+
+        // ── Properties ───────────────────────────────────────────────────
+
+        /// <summary>Current calibrated standing height in world-space Y.</summary>
+        public float StandingHeight { get; private set; }
+
+        /// <summary>True if the player is currently crouching.</summary>
+        public bool IsCrouching { get; private set; }
+
+        /// <summary>Current headset Y position.</summary>
+        public float CurrentHeadY => headsetTransform != null ? headsetTransform.position.y : 0f;
+
+        /// <summary>
+        /// Normalised crouch depth: 0 = standing, 1 = crouched crouchThreshold metres below standing.
+        /// Values above 1 are clamped.
+        /// </summary>
+        public float CrouchDepth
+        {
+            get
+            {
+                float drop = StandingHeight - CurrentHeadY;
+                return Mathf.Clamp01(drop / crouchThreshold);
+            }
+        }
+
+        // ── Private ──────────────────────────────────────────────────────
+
+        private float _prevDepth;
+
+        // ── Unity lifecycle ──────────────────────────────────────────────
+
+        private void Start()
+        {
+            ResolveHeadset();
+
+            if (autoCalibrate)
+                Calibrate();
+            else
+                StandingHeight = defaultStandingHeight;
+        }
+
+        private void Update()
+        {
+            if (headsetTransform == null)
+            {
+                ResolveHeadset();
+                return;
+            }
+
+            float drop = StandingHeight - CurrentHeadY;
+            bool wasCrouching = IsCrouching;
+
+            if (!IsCrouching && drop >= crouchThreshold)
+            {
+                IsCrouching = true;
+                OnCrouch?.Invoke();
+            }
+            else if (IsCrouching && drop < (crouchThreshold - standHysteresis))
+            {
+                IsCrouching = false;
+                OnStand?.Invoke();
+            }
+
+            float depth = CrouchDepth;
+            if (!Mathf.Approximately(depth, _prevDepth))
+            {
+                OnCrouchDepthChanged?.Invoke(depth);
+                _prevDepth = depth;
+            }
+        }
+
+        // ── Public API ───────────────────────────────────────────────────
+
+        /// <summary>
+        /// Sets standing height to current headset Y. Call while player is fully upright.
+        /// </summary>
+        public void Calibrate()
+        {
+            if (headsetTransform == null)
+                ResolveHeadset();
+
+            StandingHeight = headsetTransform != null ? headsetTransform.position.y : defaultStandingHeight;
+            Debug.Log($"[CrouchDetector] Calibrated standing height: {StandingHeight:F3} m");
+        }
+
+        /// <summary>
+        /// Manually override the standing height (e.g., restore from saved profile).
+        /// </summary>
+        public void SetStandingHeight(float height)
+        {
+            StandingHeight = height;
+        }
+
+        // ── Internal ─────────────────────────────────────────────────────
+
+        private void ResolveHeadset()
+        {
+            if (headsetTransform != null) return;
+
+#if HAS_META_XR
+            var rig = FindFirstObjectByType<OVRCameraRig>();
+            if (rig != null)
+            {
+                headsetTransform = rig.centerEyeAnchor;
+                return;
+            }
+#endif
+            var cam = Camera.main;
+            if (cam != null)
+                headsetTransform = cam.transform;
+        }
+    }
+}

--- a/Assets/Scripts/IK/CrouchDetector.cs.meta
+++ b/Assets/Scripts/IK/CrouchDetector.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9ab7dcdd7f3646c99898c7455c37914e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/IK/LeanDetector.cs
+++ b/Assets/Scripts/IK/LeanDetector.cs
@@ -1,0 +1,197 @@
+// LeanDetector.cs
+// PLAGA '44 -- Detects player leaning left/right by tracking headset X offset
+// relative to a calibrated center position (the VR rig root or a body anchor).
+// Intended for peek-around-corner mechanics.
+//
+// Namespace: Plaga44.IK
+
+using UnityEngine;
+using UnityEngine.Events;
+
+namespace Plaga44.IK
+{
+    /// <summary>
+    /// Detects physical lean by measuring the horizontal (X-axis) offset of the
+    /// headset relative to the player's rig root. Fires directional lean events.
+    /// </summary>
+    public class LeanDetector : MonoBehaviour
+    {
+        // ── Inspector ────────────────────────────────────────────────────
+
+        [Header("References")]
+        [Tooltip("The CenterEyeAnchor or Camera.main transform. Auto-found if null.")]
+        public Transform headsetTransform;
+
+        [Tooltip("The rig root whose local X axis defines 'center'. " +
+                 "Usually the OVRCameraRig or the GameObject this script is on.")]
+        public Transform rigRoot;
+
+        [Header("Thresholds")]
+        [Tooltip("Metres the head must move laterally from center before a lean is detected.")]
+        [Range(0.05f, 0.5f)]
+        public float leanThreshold = 0.12f;
+
+        [Tooltip("Hysteresis: head must return within this margin of center before OnLeanCenter fires.")]
+        [Range(0f, 0.1f)]
+        public float centerHysteresis = 0.04f;
+
+        [Header("Events")]
+        [Tooltip("Fired once when player leans to the left past the threshold.")]
+        public UnityEvent OnLeanLeft;
+
+        [Tooltip("Fired once when player leans to the right past the threshold.")]
+        public UnityEvent OnLeanRight;
+
+        [Tooltip("Fired once when player returns to center (within hysteresis band).")]
+        public UnityEvent OnLeanCenter;
+
+        [Tooltip("Fired every frame with signed lean offset in metres (negative = left, positive = right).")]
+        public UnityEvent<float> OnLeanOffsetChanged;
+
+        // ── Properties ───────────────────────────────────────────────────
+
+        /// <summary>Current lean direction.</summary>
+        public LeanDirection CurrentLean { get; private set; } = LeanDirection.Center;
+
+        /// <summary>
+        /// Signed lateral offset of the headset from the rig center in metres.
+        /// Negative = left, positive = right, in the rig's local X axis.
+        /// </summary>
+        public float LeanOffset { get; private set; }
+
+        // ── Types ────────────────────────────────────────────────────────
+
+        public enum LeanDirection { Left, Center, Right }
+
+        // ── Private ──────────────────────────────────────────────────────
+
+        private float _prevOffset;
+
+        // ── Unity lifecycle ──────────────────────────────────────────────
+
+        private void Start()
+        {
+            ResolveReferences();
+        }
+
+        private void Update()
+        {
+            if (headsetTransform == null || rigRoot == null)
+            {
+                ResolveReferences();
+                if (headsetTransform == null || rigRoot == null) return;
+            }
+
+            // Project headset world position into rig local space -- only X matters
+            Vector3 localHead = rigRoot.InverseTransformPoint(headsetTransform.position);
+            LeanOffset = localHead.x;
+
+            // Fire offset event when changed meaningfully
+            if (!Mathf.Approximately(LeanOffset, _prevOffset))
+            {
+                OnLeanOffsetChanged?.Invoke(LeanOffset);
+                _prevOffset = LeanOffset;
+            }
+
+            // State machine: Center -> Left/Right -> Center
+            switch (CurrentLean)
+            {
+                case LeanDirection.Center:
+                    if (LeanOffset <= -leanThreshold)
+                    {
+                        CurrentLean = LeanDirection.Left;
+                        OnLeanLeft?.Invoke();
+                    }
+                    else if (LeanOffset >= leanThreshold)
+                    {
+                        CurrentLean = LeanDirection.Right;
+                        OnLeanRight?.Invoke();
+                    }
+                    break;
+
+                case LeanDirection.Left:
+                    // Return to center when offset is within hysteresis
+                    if (LeanOffset >= -(leanThreshold - centerHysteresis))
+                    {
+                        // Check if crossing all the way to right
+                        if (LeanOffset >= leanThreshold)
+                        {
+                            CurrentLean = LeanDirection.Right;
+                            OnLeanCenter?.Invoke();
+                            OnLeanRight?.Invoke();
+                        }
+                        else
+                        {
+                            CurrentLean = LeanDirection.Center;
+                            OnLeanCenter?.Invoke();
+                        }
+                    }
+                    break;
+
+                case LeanDirection.Right:
+                    if (LeanOffset <= (leanThreshold - centerHysteresis))
+                    {
+                        if (LeanOffset <= -leanThreshold)
+                        {
+                            CurrentLean = LeanDirection.Left;
+                            OnLeanCenter?.Invoke();
+                            OnLeanLeft?.Invoke();
+                        }
+                        else
+                        {
+                            CurrentLean = LeanDirection.Center;
+                            OnLeanCenter?.Invoke();
+                        }
+                    }
+                    break;
+            }
+        }
+
+        // ── Public API ───────────────────────────────────────────────────
+
+        /// <summary>
+        /// Returns normalised lean amount: -1 = fully left, 0 = center, 1 = fully right.
+        /// Clamped to [-1, 1].
+        /// </summary>
+        public float GetNormalisedLean()
+        {
+            return Mathf.Clamp(LeanOffset / leanThreshold, -1f, 1f);
+        }
+
+        /// <summary>
+        /// Recalibrate center: sets the rig root reference frame to the player's current position.
+        /// Call when the player repositions (e.g., after teleport).
+        /// </summary>
+        public void RecalibrateCenter()
+        {
+            // Re-resolve references in case rig moved
+            ResolveReferences();
+            Debug.Log($"[LeanDetector] Center recalibrated. Current offset: {LeanOffset:F3} m");
+        }
+
+        // ── Internal ─────────────────────────────────────────────────────
+
+        private void ResolveReferences()
+        {
+            if (headsetTransform == null)
+            {
+#if HAS_META_XR
+                var rig = FindFirstObjectByType<OVRCameraRig>();
+                if (rig != null)
+                {
+                    headsetTransform = rig.centerEyeAnchor;
+                    if (rigRoot == null)
+                        rigRoot = rig.transform;
+                    return;
+                }
+#endif
+                var cam = Camera.main;
+                if (cam != null)
+                    headsetTransform = cam.transform;
+            }
+
+            if (rigRoot == null)
+                rigRoot = transform;
+        }
+    }
+}

--- a/Assets/Scripts/IK/LeanDetector.cs.meta
+++ b/Assets/Scripts/IK/LeanDetector.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 810b0fc293c547ddb100d394959381cf
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/IK/SeatInteractable.cs
+++ b/Assets/Scripts/IK/SeatInteractable.cs
@@ -1,0 +1,204 @@
+// SeatInteractable.cs
+// PLAGA '44 -- Place this on any seat object (chair, crate, ground).
+// Requires a Trigger Collider on the same GameObject or a child.
+// When the VR player enters the trigger zone: hips are pinned to the seat point
+// and SimpleIKController is activated (full weight) so legs rest naturally.
+// Player exits by pressing the configured eject button or moving away.
+//
+// Namespace: Plaga44.IK
+
+using UnityEngine;
+using UnityEngine.Events;
+
+namespace Plaga44.IK
+{
+    /// <summary>
+    /// Seat interactable. Pins the player's hips to a defined seat point and
+    /// activates leg IK so legs rest on the floor rather than floating.
+    /// </summary>
+    [RequireComponent(typeof(Collider))]
+    public class SeatInteractable : MonoBehaviour
+    {
+        // ── Inspector ────────────────────────────────────────────────────
+
+        [Header("Seat Configuration")]
+        [Tooltip("The exact world-space point where the player's hips are placed when seated. " +
+                 "If null the transform of this GameObject is used.")]
+        public Transform seatPoint;
+
+        [Tooltip("Tag that identifies the VR player rig root collider.")]
+        public string playerTag = "Player";
+
+        [Tooltip("Transform that represents the player's hip/waist anchor. " +
+                 "If null, the component searches the player for a child named 'Hips' or 'Hip'.")]
+        public Transform hipAnchor;
+
+        [Tooltip("SimpleIKController on the player rig. Auto-found via GetComponentInChildren if null.")]
+        public SimpleIKController ikController;
+
+        [Header("Eject")]
+#if HAS_META_XR
+        [Tooltip("OVR button that ejects the player from the seat (requires Meta XR SDK).")]
+        public OVRInput.Button ejectButton = OVRInput.Button.Two; // B / Y
+#endif
+
+        [Tooltip("Minimum seconds the player must be seated before the eject button works. " +
+                 "Prevents accidental instant eject.")]
+        [Range(0.1f, 2f)]
+        public float ejectCooldown = 0.5f;
+
+        [Header("Hip Pinning")]
+        [Tooltip("How strongly the hip is pulled to the seat point. 1 = snapped instantly.")]
+        [Range(1f, 30f)]
+        public float hipPinSpeed = 15f;
+
+        [Tooltip("Offset applied on top of seatPoint: adjusts height of sitting pose.")]
+        public Vector3 hipOffset = new Vector3(0f, 0.05f, 0f);
+
+        [Header("Events")]
+        public UnityEvent<Transform> OnSit;   // Passes the player transform
+        public UnityEvent<Transform> OnStand; // Passes the player transform
+
+        // ── Private ──────────────────────────────────────────────────────
+
+        private bool _isSeated;
+        private Transform _playerRoot;
+        private Transform _resolvedHip;
+        private Vector3 _hipOriginalLocalPos;
+        private float _seatedTime;
+
+        // ── Unity lifecycle ──────────────────────────────────────────────
+
+        private void Awake()
+        {
+            // Make sure the collider is a trigger
+            var col = GetComponent<Collider>();
+            if (col != null && !col.isTrigger)
+            {
+                col.isTrigger = true;
+                Debug.LogWarning($"[SeatInteractable] '{name}': Collider was not a trigger -- set automatically.", this);
+            }
+
+            if (seatPoint == null)
+                seatPoint = transform;
+        }
+
+        private void Update()
+        {
+            if (!_isSeated || _playerRoot == null) return;
+
+            _seatedTime += Time.deltaTime;
+
+            // Pin hips each frame
+            PinHips();
+
+            // Eject on button press (after cooldown)
+            if (_seatedTime >= ejectCooldown)
+            {
+#if HAS_META_XR
+                if (OVRInput.GetDown(ejectButton))
+                {
+                    Eject();
+                    return;
+                }
+#endif
+            }
+        }
+
+        // ── Trigger detection ────────────────────────────────────────────
+
+        private void OnTriggerEnter(Collider other)
+        {
+            if (_isSeated) return;
+            if (!other.CompareTag(playerTag)) return;
+
+            Transform playerRoot = other.transform.root;
+            TrySit(playerRoot);
+        }
+
+        private void OnTriggerExit(Collider other)
+        {
+            if (!_isSeated) return;
+            if (!other.CompareTag(playerTag)) return;
+
+            // Only eject if this is the same player
+            if (other.transform.root == _playerRoot)
+                Eject();
+        }
+
+        // ── Sit / Stand ──────────────────────────────────────────────────
+
+        private void TrySit(Transform playerRoot)
+        {
+            _playerRoot = playerRoot;
+
+            // Resolve hip anchor
+            _resolvedHip = hipAnchor;
+            if (_resolvedHip == null)
+            {
+                _resolvedHip = playerRoot.Find("Hips") ?? playerRoot.Find("Hip");
+                if (_resolvedHip == null)
+                {
+                    Debug.LogWarning($"[SeatInteractable] '{name}': Could not find Hips transform on player. " +
+                                     "Assign hipAnchor manually or name the bone 'Hips'.", this);
+                }
+            }
+
+            if (_resolvedHip != null)
+                _hipOriginalLocalPos = _resolvedHip.localPosition;
+
+            // Find and enable IK
+            if (ikController == null)
+                ikController = playerRoot.GetComponentInChildren<SimpleIKController>();
+
+            if (ikController != null)
+                ikController.SetIKWeight(1f);
+
+            _isSeated = true;
+            _seatedTime = 0f;
+
+            OnSit?.Invoke(playerRoot);
+            Debug.Log($"[SeatInteractable] Player sat on '{name}'.");
+        }
+
+        private void Eject()
+        {
+            if (!_isSeated) return;
+
+            // Restore hip to its local-space rest pose
+            if (_resolvedHip != null)
+                _resolvedHip.localPosition = _hipOriginalLocalPos;
+
+            // Fade out IK slightly so the stand-up looks natural
+            if (ikController != null)
+                ikController.SetIKWeight(0.5f);
+
+            var prev = _playerRoot;
+            _playerRoot = null;
+            _resolvedHip = null;
+            _isSeated = false;
+
+            OnStand?.Invoke(prev);
+            Debug.Log($"[SeatInteractable] Player stood up from '{name}'.");
+        }
+
+        private void PinHips()
+        {
+            if (_resolvedHip == null) return;
+
+            Vector3 targetWorld = seatPoint.position + seatPoint.TransformDirection(hipOffset);
+            _resolvedHip.position = Vector3.Lerp(
+                _resolvedHip.position,
+                targetWorld,
+                hipPinSpeed * Time.deltaTime);
+        }
+
+        // ── Public API ───────────────────────────────────────────────────
+
+        /// <summary>Returns true if a player is currently using this seat.</summary>
+        public bool IsOccupied => _isSeated;
+
+        /// <summary>Force-eject the current occupant (e.g., seat is destroyed).</summary>
+        public void ForceEject() => Eject();
+    }
+}

--- a/Assets/Scripts/IK/SeatInteractable.cs.meta
+++ b/Assets/Scripts/IK/SeatInteractable.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3254b987bb9b45c0959a20b1d6fc9b56
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/IK/SimpleIKController.cs
+++ b/Assets/Scripts/IK/SimpleIKController.cs
@@ -1,0 +1,281 @@
+// SimpleIKController.cs
+// PLAGA '44 -- Two-bone IK solver for VR legs.
+// Handles foot grounding via raycasts so feet stay on floors/stairs/slopes.
+// Attach to the VR rig root. Assign left/right foot transforms and their
+// corresponding IK target/hint transforms (created procedurally or by hand).
+//
+// Namespace: Plaga44.IK
+
+using UnityEngine;
+using UnityEngine.Events;
+
+namespace Plaga44.IK
+{
+    /// <summary>
+    /// Lightweight two-bone IK solver for VR player legs.
+    /// Performs foot grounding with raycasts and exposes ikWeight to fade in/out.
+    /// Works without Animator -- drives transforms directly.
+    /// </summary>
+    public class SimpleIKController : MonoBehaviour
+    {
+        // ── Inspector ────────────────────────────────────────────────────
+
+        [Header("Foot Bones")]
+        [Tooltip("Upper leg bone (hip joint) -- left side.")]
+        public Transform leftUpperLeg;
+
+        [Tooltip("Lower leg bone (knee joint) -- left side.")]
+        public Transform leftLowerLeg;
+
+        [Tooltip("Foot bone -- left side.")]
+        public Transform leftFoot;
+
+        [Tooltip("Upper leg bone (hip joint) -- right side.")]
+        public Transform rightUpperLeg;
+
+        [Tooltip("Lower leg bone (knee joint) -- right side.")]
+        public Transform rightLowerLeg;
+
+        [Tooltip("Foot bone -- right side.")]
+        public Transform rightFoot;
+
+        [Header("IK Targets (optional -- auto-created if null)")]
+        [Tooltip("World-space target for left foot. Created at runtime if null.")]
+        public Transform leftFootTarget;
+
+        [Tooltip("World-space target for right foot. Created at runtime if null.")]
+        public Transform rightFootTarget;
+
+        [Header("Grounding")]
+        [Tooltip("LayerMask used for floor raycasts.")]
+        public LayerMask groundLayer = ~0;
+
+        [Tooltip("Vertical offset of foot above the ground hit point.")]
+        [Range(0f, 0.2f)]
+        public float footOffset = 0.04f;
+
+        [Tooltip("How far above the foot to start the downward raycast.")]
+        [Range(0.1f, 1.0f)]
+        public float raycastOriginHeight = 0.6f;
+
+        [Tooltip("Maximum downward reach of the raycast.")]
+        [Range(0.2f, 2.0f)]
+        public float raycastDistance = 1.2f;
+
+        [Tooltip("How quickly the foot target tracks the grounded position.")]
+        [Range(1f, 30f)]
+        public float footTrackingSpeed = 12f;
+
+        [Header("IK Weight")]
+        [Tooltip("Global blend factor: 0 = no IK, 1 = full IK.")]
+        [Range(0f, 1f)]
+        public float ikWeight = 1f;
+
+        [Tooltip("Speed at which ikWeight fades when changed via SetIKWeight().")]
+        [Range(0.5f, 20f)]
+        public float ikWeightFadeSpeed = 5f;
+
+        [Header("Events")]
+        public UnityEvent onLeftFootGrounded;
+        public UnityEvent onRightFootGrounded;
+
+        // ── Private ──────────────────────────────────────────────────────
+
+        private float _targetIKWeight = 1f;
+
+        // Cached initial leg lengths (computed once from bone positions)
+        private float _leftUpperLength;
+        private float _leftLowerLength;
+        private float _rightUpperLength;
+        private float _rightLowerLength;
+
+        // Grounded positions (smoothed)
+        private Vector3 _leftFootGroundPos;
+        private Vector3 _rightFootGroundPos;
+        private Quaternion _leftFootGroundRot;
+        private Quaternion _rightFootGroundRot;
+        private bool _leftGrounded;
+        private bool _rightGrounded;
+
+        // ── Unity lifecycle ──────────────────────────────────────────────
+
+        private void Start()
+        {
+            if (leftUpperLeg != null && leftLowerLeg != null && leftFoot != null)
+            {
+                _leftUpperLength = Vector3.Distance(leftUpperLeg.position, leftLowerLeg.position);
+                _leftLowerLength = Vector3.Distance(leftLowerLeg.position, leftFoot.position);
+            }
+
+            if (rightUpperLeg != null && rightLowerLeg != null && rightFoot != null)
+            {
+                _rightUpperLength = Vector3.Distance(rightUpperLeg.position, rightLowerLeg.position);
+                _rightLowerLength = Vector3.Distance(rightLowerLeg.position, rightFoot.position);
+            }
+
+            // Auto-create foot targets if not assigned
+            if (leftFoot != null && leftFootTarget == null)
+            {
+                var go = new GameObject("IK_LeftFootTarget");
+                go.transform.position = leftFoot.position;
+                go.transform.rotation = leftFoot.rotation;
+                leftFootTarget = go.transform;
+            }
+
+            if (rightFoot != null && rightFootTarget == null)
+            {
+                var go = new GameObject("IK_RightFootTarget");
+                go.transform.position = rightFoot.position;
+                go.transform.rotation = rightFoot.rotation;
+                rightFootTarget = go.transform;
+            }
+
+            _leftFootGroundPos = leftFoot != null ? leftFoot.position : Vector3.zero;
+            _rightFootGroundPos = rightFoot != null ? rightFoot.position : Vector3.zero;
+        }
+
+        private void LateUpdate()
+        {
+            // Fade ikWeight toward target
+            if (!Mathf.Approximately(ikWeight, _targetIKWeight))
+                ikWeight = Mathf.MoveTowards(ikWeight, _targetIKWeight, ikWeightFadeSpeed * Time.deltaTime);
+
+            if (ikWeight <= 0f) return;
+
+            UpdateFootGrounding(
+                leftFoot, leftFootTarget,
+                ref _leftFootGroundPos, ref _leftFootGroundRot, ref _leftGrounded,
+                onLeftFootGrounded);
+
+            UpdateFootGrounding(
+                rightFoot, rightFootTarget,
+                ref _rightFootGroundPos, ref _rightFootGroundRot, ref _rightGrounded,
+                onRightFootGrounded);
+
+            // Solve IK for both legs
+            if (leftUpperLeg != null && leftLowerLeg != null && leftFoot != null && leftFootTarget != null)
+                SolveTwoBoneIK(leftUpperLeg, leftLowerLeg, leftFoot, leftFootTarget, _leftUpperLength, _leftLowerLength);
+
+            if (rightUpperLeg != null && rightLowerLeg != null && rightFoot != null && rightFootTarget != null)
+                SolveTwoBoneIK(rightUpperLeg, rightLowerLeg, rightFoot, rightFootTarget, _rightUpperLength, _rightLowerLength);
+        }
+
+        // ── Grounding ────────────────────────────────────────────────────
+
+        private void UpdateFootGrounding(
+            Transform foot,
+            Transform target,
+            ref Vector3 groundPos,
+            ref Quaternion groundRot,
+            ref bool wasGrounded,
+            UnityEvent groundedEvent)
+        {
+            if (foot == null || target == null) return;
+
+            Vector3 origin = foot.position + Vector3.up * raycastOriginHeight;
+
+            if (Physics.Raycast(origin, Vector3.down, out RaycastHit hit, raycastDistance, groundLayer))
+            {
+                Vector3 desiredPos = hit.point + Vector3.up * footOffset;
+                Quaternion desiredRot = Quaternion.FromToRotation(Vector3.up, hit.normal) * foot.rotation;
+
+                groundPos = Vector3.Lerp(groundPos, desiredPos, footTrackingSpeed * Time.deltaTime);
+                groundRot = Quaternion.Slerp(groundRot, desiredRot, footTrackingSpeed * Time.deltaTime);
+
+                if (!wasGrounded)
+                {
+                    wasGrounded = true;
+                    groundedEvent?.Invoke();
+                }
+            }
+            else
+            {
+                // Not hitting ground -- relax toward current foot position
+                groundPos = Vector3.Lerp(groundPos, foot.position, footTrackingSpeed * Time.deltaTime);
+                groundRot = Quaternion.Slerp(groundRot, foot.rotation, footTrackingSpeed * Time.deltaTime);
+                wasGrounded = false;
+            }
+
+            // Apply with weight blend
+            target.position = Vector3.Lerp(foot.position, groundPos, ikWeight);
+            target.rotation = Quaternion.Slerp(foot.rotation, groundRot, ikWeight);
+        }
+
+        // ── Two-Bone IK Solver ────────────────────────────────────────────
+
+        /// <summary>
+        /// Classic two-bone IK (FABRIK-lite).
+        /// Rotates upper and lower bones so that the end effector reaches targetTransform.
+        /// Uses the cross product of the limb plane as the pole/hint direction.
+        /// </summary>
+        private void SolveTwoBoneIK(
+            Transform upper,
+            Transform lower,
+            Transform end,
+            Transform target,
+            float upperLength,
+            float lowerLength)
+        {
+            Vector3 rootPos = upper.position;
+            Vector3 targetPos = target.position;
+            Quaternion targetRot = target.rotation;
+
+            Vector3 toTarget = targetPos - rootPos;
+            float totalLength = upperLength + lowerLength;
+            float dist = Mathf.Clamp(toTarget.magnitude, 0.001f, totalLength - 0.001f);
+
+            // Cosine rule to find angle at the upper joint
+            float cosUpper = (upperLength * upperLength + dist * dist - lowerLength * lowerLength)
+                             / (2f * upperLength * dist);
+            cosUpper = Mathf.Clamp(cosUpper, -1f, 1f);
+            float angleUpper = Mathf.Acos(cosUpper) * Mathf.Rad2Deg;
+
+            // Pole vector: perpendicular to limb plane (prefer forward as fallback)
+            Vector3 up = Vector3.Cross(toTarget, Vector3.Cross(toTarget, upper.forward)).normalized;
+            if (up == Vector3.zero)
+                up = Vector3.Cross(toTarget, Vector3.right).normalized;
+
+            // Rotate upper bone toward target, then bend by knee angle
+            Quaternion lookRot = Quaternion.LookRotation(toTarget.normalized, up);
+            upper.rotation = Quaternion.Lerp(
+                upper.rotation,
+                lookRot * Quaternion.Euler(-(angleUpper), 0f, 0f),
+                ikWeight);
+
+            // Lower bone: point from knee toward target, then bend
+            Vector3 kneePos = upper.position + upper.rotation * (Vector3.forward * upperLength);
+            Vector3 toLower = targetPos - kneePos;
+
+            float cosLower = (lowerLength * lowerLength + dist * dist - upperLength * upperLength)
+                             / (2f * lowerLength * dist);
+            cosLower = Mathf.Clamp(cosLower, -1f, 1f);
+            float angleLower = 180f - Mathf.Acos(cosLower) * Mathf.Rad2Deg;
+
+            lower.rotation = Quaternion.Lerp(
+                lower.rotation,
+                Quaternion.LookRotation(toLower.normalized, up) * Quaternion.Euler(angleLower, 0f, 0f),
+                ikWeight);
+
+            // Blend end effector rotation
+            end.rotation = Quaternion.Lerp(end.rotation, targetRot, ikWeight);
+        }
+
+        // ── Public API ───────────────────────────────────────────────────
+
+        /// <summary>
+        /// Fades ikWeight toward the given value using ikWeightFadeSpeed.
+        /// </summary>
+        public void SetIKWeight(float weight)
+        {
+            _targetIKWeight = Mathf.Clamp01(weight);
+        }
+
+        /// <summary>
+        /// Instantly sets ikWeight with no fade.
+        /// </summary>
+        public void SetIKWeightImmediate(float weight)
+        {
+            ikWeight = _targetIKWeight = Mathf.Clamp01(weight);
+        }
+    }
+}

--- a/Assets/Scripts/IK/SimpleIKController.cs.meta
+++ b/Assets/Scripts/IK/SimpleIKController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ebbbdc309f29448bbf05cfd7744a46b4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary

- **SimpleIKController** -- two-bone IK solver for VR player legs; foot grounding via downward raycasts; configurable `groundLayer`, `footOffset`, `ikWeight` with smooth fade
- **SeatInteractable** -- trigger collider on any seat object; pins hips to `seatPoint` each frame; activates `SimpleIKController` (weight 1.0) on sit; ejects on OVR button B/Y (guarded by `#if HAS_META_XR`); `OnSit` / `OnStand` UnityEvents
- **CrouchDetector** -- measures headset Y vs calibrated standing height; fires `OnCrouch` / `OnStand` with hysteresis; `OnCrouchDepthChanged(float)` for analogue cover blend
- **LeanDetector** -- measures headset local X offset from rig root; fires `OnLeanLeft` / `OnLeanRight` / `OnLeanCenter`; `GetNormalisedLean()` returns -1..1 for peek-around-corner blend

All scripts: `namespace Plaga44.IK`, `Assets/Scripts/IK/`.  
OVR-specific code guarded by `#if HAS_META_XR` -- compiles cleanly without Meta XR SDK.

Closes #41

## Test plan

- [ ] Open Unity 6 (6000.3.7f1), let it reimport -- confirm no compile errors in Console
- [ ] Create empty GameObject, add **SimpleIKController**, assign left/right leg bone transforms, enter Play mode -- foot targets should appear and track floor via raycasts
- [ ] Place a cube in scene, add **SeatInteractable** + Trigger Collider, tag player root as `Player`, walk VR rig into trigger -- Console should log "Player sat on..."
- [ ] Add **CrouchDetector** to rig root, set `autoCalibrate = true`, enter Play -- physically crouch (or lower headset Y in editor): `OnCrouch` event fires, depth value 0-1 updates
- [ ] Add **LeanDetector** to rig root, enter Play -- move headset X past 0.12 m threshold: `OnLeanLeft` / `OnLeanRight` fires; return to center: `OnLeanCenter` fires
- [ ] Build for Android (ARM64 IL2CPP) and verify no IL2CPP stripping errors related to Plaga44.IK
Closes #41