### PR TITLE
feat: Application SpaceWarp + performance monitoring (#44)

### DIFF
--- a/Assets/Scripts/Performance.meta
+++ b/Assets/Scripts/Performance.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: cea59bd49ca94df0a3cc93f95673fdf4
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Performance/PerformanceMonitor.cs
+++ b/Assets/Scripts/Performance/PerformanceMonitor.cs
@@ -1,0 +1,260 @@
+// PerformanceMonitor.cs
+// CYBERNOMAD -- Real-time VR performance metrics with HUD overlay.
+// Tracks FPS, GPU time, CPU time (via OVRManager.GetGPUUtilLevel / GetCPULevel if available).
+// Fires events OnPerformanceDrop / OnPerformanceRecover when FPS crosses dropThreshold.
+// Debug HUD: world-space canvas anchored in front of headset, toggled via ToggleHud().
+//
+// Requires Meta XR SDK for GPU/CPU stats (graceful fallback without it).
+
+using System;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace Plaga44.Performance
+{
+    /// <summary>
+    /// MonoBehaviour that collects real-time performance metrics and exposes them
+    /// as events and an optional debug HUD.
+    /// </summary>
+    public class PerformanceMonitor : MonoBehaviour
+    {
+        // ── Inspector config ─────────────────────────────────────────────────
+
+        [Header("Sampling")]
+        [Tooltip("How often (seconds) to compute average metrics and fire events.")]
+        [Range(0.2f, 5f)]
+        public float sampleInterval = 1f;
+
+        [Header("Performance Drop Detection")]
+        [Tooltip("FPS below this value triggers OnPerformanceDrop.")]
+        [Range(20f, 90f)]
+        public float dropThreshold = 60f;
+
+        [Tooltip("FPS must stay above dropThreshold + hysteresis to trigger OnPerformanceRecover.")]
+        [Range(0f, 20f)]
+        public float recoveryHysteresis = 5f;
+
+        [Header("HUD")]
+        [Tooltip("Show debug HUD on start.")]
+        public bool showHudOnStart = false;
+
+        [Tooltip("Distance from the headset camera at which the HUD floats.")]
+        [Range(0.3f, 2f)]
+        public float hudDistance = 0.4f;
+
+        // ── Events ───────────────────────────────────────────────────────────
+
+        /// <summary>Fired when average FPS drops below dropThreshold. Arg = current avg FPS.</summary>
+        public event Action<float> OnPerformanceDrop;
+
+        /// <summary>Fired when average FPS recovers above dropThreshold + recoveryHysteresis.</summary>
+        public event Action<float> OnPerformanceRecover;
+
+        // ── Public read-only metrics ─────────────────────────────────────────
+
+        public float CurrentFps       { get; private set; }
+        public float AverageFps       { get; private set; }
+        public float GpuUtilLevel     { get; private set; }  // 0-4 scale (Meta) or -1 if unavailable
+        public float CpuLevel         { get; private set; }  // 0-4 scale (Meta) or -1 if unavailable
+        public bool  IsInDropState    { get; private set; }
+
+        // ── Internal ─────────────────────────────────────────────────────────
+
+        private float _sampleTimer     = 0f;
+        private float _fpsAccumulator  = 0f;
+        private int   _fpsFrames       = 0;
+
+        private Transform _headTransform;
+
+        // HUD refs
+        private Canvas _hudCanvas;
+        private Text   _hudText;
+        private bool   _hudVisible      = false;
+        private const float HudScale    = 0.0004f;
+
+        // ── Unity lifecycle ──────────────────────────────────────────────────
+
+        private void Start()
+        {
+            GpuUtilLevel = -1f;
+            CpuLevel     = -1f;
+
+            CreateHud();
+
+            if (showHudOnStart)
+                ShowHud();
+            else
+                HideHud();
+        }
+
+        private void Update()
+        {
+            if (Time.unscaledDeltaTime > 0f)
+            {
+                CurrentFps       = 1f / Time.unscaledDeltaTime;
+                _fpsAccumulator += CurrentFps;
+                _fpsFrames++;
+            }
+
+            _sampleTimer += Time.unscaledDeltaTime;
+
+            if (_sampleTimer >= sampleInterval)
+            {
+                AverageFps      = (_fpsFrames > 0) ? (_fpsAccumulator / _fpsFrames) : 0f;
+                _fpsAccumulator = 0f;
+                _fpsFrames      = 0;
+                _sampleTimer    = 0f;
+
+                SamplePlatformStats();
+                CheckDropRecover();
+            }
+
+            if (_hudVisible)
+                UpdateHud();
+        }
+
+        // ── Public API ───────────────────────────────────────────────────────
+
+        /// <summary>Toggle HUD visibility.</summary>
+        public void ToggleHud()
+        {
+            if (_hudVisible) HideHud();
+            else             ShowHud();
+        }
+
+        public void ShowHud() { _hudVisible = true;  _hudCanvas?.gameObject.SetActive(true); }
+        public void HideHud() { _hudVisible = false; _hudCanvas?.gameObject.SetActive(false); }
+
+        // ── Internal helpers ─────────────────────────────────────────────────
+
+        private void SamplePlatformStats()
+        {
+#if HAS_META_XR
+            // OVRManager exposes CPU/GPU level as integer 0-4 (power level, not utilization %).
+            // GetGPUUtilLevel / GetCPULevel are static -- available without an OVRManager instance.
+            GpuUtilLevel = OVRPlugin.gpuUtilSupported ? OVRPlugin.gpuUtilLevel : -1f;
+            CpuLevel     = (float)OVRPlugin.cpuLevel;
+#endif
+        }
+
+        private void CheckDropRecover()
+        {
+            if (!IsInDropState && AverageFps < dropThreshold)
+            {
+                IsInDropState = true;
+                Debug.Log($"[PerformanceMonitor] PERFORMANCE DROP: avgFPS={AverageFps:F1} < threshold={dropThreshold}");
+                OnPerformanceDrop?.Invoke(AverageFps);
+            }
+            else if (IsInDropState && AverageFps >= dropThreshold + recoveryHysteresis)
+            {
+                IsInDropState = false;
+                Debug.Log($"[PerformanceMonitor] PERFORMANCE RECOVERED: avgFPS={AverageFps:F1}");
+                OnPerformanceRecover?.Invoke(AverageFps);
+            }
+        }
+
+        // ── HUD ──────────────────────────────────────────────────────────────
+
+        private void UpdateHud()
+        {
+            // Anchor to head each frame.
+            if (_headTransform == null) FindHead();
+
+            if (_headTransform != null)
+            {
+                _hudCanvas.transform.position = _headTransform.position + _headTransform.forward * hudDistance;
+                _hudCanvas.transform.rotation = _headTransform.rotation;
+            }
+
+            if (_hudText == null) return;
+
+            string fpsColor  = AverageFps >= dropThreshold + recoveryHysteresis ? "#0f0"
+                             : AverageFps >= dropThreshold                       ? "#ff0"
+                             :                                                     "#f00";
+
+            string dropLabel = IsInDropState ? " <color=#f00>[DROP]</color>" : "";
+
+            string gpuStr = GpuUtilLevel >= 0f ? $"{GpuUtilLevel:F0}/4" : "N/A";
+            string cpuStr = CpuLevel     >= 0f ? $"{CpuLevel:F0}/4"     : "N/A";
+
+#if HAS_META_XR
+            bool aswActive = SpaceWarpManager.Instance != null && SpaceWarpManager.Instance.IsSpaceWarpActive;
+            string aswStr  = aswActive ? "<color=#0ff>ON</color>" : "<color=#888>OFF</color>";
+#else
+            string aswStr = "<color=#888>N/A</color>";
+#endif
+
+            _hudText.text =
+                $"<b>=== PERF MONITOR ===</b>\n" +
+                $"FPS now:  <color={fpsColor}>{CurrentFps:F0}</color>{dropLabel}\n" +
+                $"FPS avg:  <color={fpsColor}>{AverageFps:F1}</color>\n" +
+                $"GPU lvl:  {gpuStr}\n" +
+                $"CPU lvl:  {cpuStr}\n" +
+                $"ASW:      {aswStr}\n" +
+                $"Frame:    {Time.frameCount}";
+        }
+
+        private void FindHead()
+        {
+#if HAS_META_XR
+            var rig = FindFirstObjectByType<OVRCameraRig>();
+            if (rig != null)
+            {
+                _headTransform = rig.centerEyeAnchor;
+                return;
+            }
+#endif
+            var cam = Camera.main;
+            if (cam != null) _headTransform = cam.transform;
+        }
+
+        private void CreateHud()
+        {
+            var go = new GameObject("PerformanceMonitor_HUD");
+            go.transform.SetParent(transform);
+
+            _hudCanvas = go.AddComponent<Canvas>();
+            _hudCanvas.renderMode = RenderMode.WorldSpace;
+            _hudCanvas.sortingOrder = 9998;
+
+            var rect = _hudCanvas.GetComponent<RectTransform>();
+            rect.sizeDelta  = new Vector2(340, 200);
+            rect.localScale = Vector3.one * HudScale;
+
+            // Background panel
+            var bgGo  = new GameObject("BG");
+            bgGo.transform.SetParent(go.transform, false);
+            var bg    = bgGo.AddComponent<Image>();
+            bg.color  = new Color(0f, 0f, 0f, 0.7f);
+            var bgRect = bgGo.GetComponent<RectTransform>();
+            bgRect.anchorMin  = Vector2.zero;
+            bgRect.anchorMax  = Vector2.one;
+            bgRect.sizeDelta  = Vector2.zero;
+            bgRect.offsetMin  = new Vector2(-6, -6);
+            bgRect.offsetMax  = new Vector2(6, 6);
+
+            // Text
+            var txtGo = new GameObject("HudText");
+            txtGo.transform.SetParent(go.transform, false);
+            _hudText = txtGo.AddComponent<Text>();
+            _hudText.font         = Font.CreateDynamicFontFromOSFont("Consolas", 18);
+            _hudText.fontSize     = 18;
+            _hudText.color        = Color.white;
+            _hudText.alignment    = TextAnchor.UpperLeft;
+            _hudText.supportRichText      = true;
+            _hudText.horizontalOverflow   = HorizontalWrapMode.Overflow;
+            _hudText.verticalOverflow     = VerticalWrapMode.Overflow;
+
+            var txtRect = txtGo.GetComponent<RectTransform>();
+            txtRect.anchorMin       = new Vector2(0f, 1f);
+            txtRect.anchorMax       = new Vector2(0f, 1f);
+            txtRect.pivot           = new Vector2(0f, 1f);
+            txtRect.anchoredPosition = new Vector2(8f, -8f);
+            txtRect.sizeDelta        = new Vector2(330, 190);
+
+            var outline         = txtGo.AddComponent<Outline>();
+            outline.effectColor = new Color(0f, 0f, 0f, 0.9f);
+            outline.effectDistance = new Vector2(1, -1);
+        }
+    }
+}

--- a/Assets/Scripts/Performance/PerformanceMonitor.cs.meta
+++ b/Assets/Scripts/Performance/PerformanceMonitor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2e492041d1cc4faa8ec17ec0971bc097
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Performance/QualityScaler.cs
+++ b/Assets/Scripts/Performance/QualityScaler.cs
@@ -1,0 +1,254 @@
+// QualityScaler.cs
+// CYBERNOMAD -- Dynamic quality scaling in response to performance drops.
+// Listens to PerformanceMonitor events and progressively reduces:
+//   1. Render scale (XRSettings.eyeTextureResolutionScale)
+//   2. Shadow distance (QualitySettings.shadowDistance)
+//   3. LOD bias (QualitySettings.lodBias)
+// Restores quality incrementally when FPS recovers.
+//
+// Requires PerformanceMonitor on the same or sibling GameObject.
+
+using UnityEngine;
+using UnityEngine.XR;
+
+namespace Plaga44.Performance
+{
+    /// <summary>
+    /// Dynamically scales render quality up/down based on PerformanceMonitor events.
+    /// Attach alongside or as a child of a PerformanceMonitor.
+    /// </summary>
+    public class QualityScaler : MonoBehaviour
+    {
+        // ── Inspector config ─────────────────────────────────────────────────
+
+        [Header("Render Scale")]
+        [Tooltip("Maximum (baseline) render scale. 1.0 = native resolution.")]
+        [Range(0.5f, 2f)]
+        public float maxRenderScale = 1.0f;
+
+        [Tooltip("Minimum render scale to drop to under load.")]
+        [Range(0.3f, 1f)]
+        public float minRenderScale = 0.7f;
+
+        [Tooltip("How much to change render scale per step.")]
+        [Range(0.05f, 0.3f)]
+        public float renderScaleStep = 0.1f;
+
+        [Header("Shadow Distance")]
+        [Tooltip("Baseline shadow distance in world units.")]
+        [Range(5f, 100f)]
+        public float maxShadowDistance = 35f;
+
+        [Tooltip("Minimum shadow distance under load.")]
+        [Range(0f, 30f)]
+        public float minShadowDistance = 8f;
+
+        [Tooltip("Shadow distance reduction per drop step.")]
+        [Range(1f, 20f)]
+        public float shadowStep = 8f;
+
+        [Header("LOD Bias")]
+        [Tooltip("Baseline LOD bias (higher = higher quality models further away).")]
+        [Range(0.3f, 2f)]
+        public float maxLodBias = 1.0f;
+
+        [Tooltip("Minimum LOD bias under load.")]
+        [Range(0.1f, 1f)]
+        public float minLodBias = 0.4f;
+
+        [Tooltip("LOD bias reduction per drop step.")]
+        [Range(0.05f, 0.4f)]
+        public float lodBiasStep = 0.15f;
+
+        [Header("Recovery")]
+        [Tooltip("Seconds between each incremental quality restore step after recovery.")]
+        [Range(1f, 30f)]
+        public float recoveryStepInterval = 5f;
+
+        // ── Internal state ───────────────────────────────────────────────────
+
+        private PerformanceMonitor _monitor;
+
+        private float _currentRenderScale;
+        private float _currentShadowDistance;
+        private float _currentLodBias;
+
+        private bool  _recovering    = false;
+        private float _recoveryTimer = 0f;
+
+        // ── Properties (read-only metrics) ───────────────────────────────────
+
+        public float CurrentRenderScale     => _currentRenderScale;
+        public float CurrentShadowDistance  => _currentShadowDistance;
+        public float CurrentLodBias         => _currentLodBias;
+
+        // ── Unity lifecycle ──────────────────────────────────────────────────
+
+        private void Start()
+        {
+            // Snapshot baselines from current project settings.
+            _currentRenderScale    = Mathf.Clamp(XRSettings.eyeTextureResolutionScale, minRenderScale, maxRenderScale);
+            _currentShadowDistance = Mathf.Clamp(QualitySettings.shadowDistance,        minShadowDistance, maxShadowDistance);
+            _currentLodBias        = Mathf.Clamp((float)QualitySettings.lodBias,         minLodBias, maxLodBias);
+
+            // Wire up to PerformanceMonitor.
+            _monitor = GetComponent<PerformanceMonitor>();
+            if (_monitor == null)
+                _monitor = GetComponentInParent<PerformanceMonitor>();
+            if (_monitor == null)
+                _monitor = FindFirstObjectByType<PerformanceMonitor>();
+
+            if (_monitor != null)
+            {
+                _monitor.OnPerformanceDrop    += HandlePerformanceDrop;
+                _monitor.OnPerformanceRecover += HandlePerformanceRecover;
+                Debug.Log("[QualityScaler] Wired to PerformanceMonitor.");
+            }
+            else
+            {
+                Debug.LogWarning("[QualityScaler] No PerformanceMonitor found -- QualityScaler is inactive.");
+            }
+        }
+
+        private void Update()
+        {
+            if (!_recovering) return;
+
+            _recoveryTimer += Time.unscaledDeltaTime;
+
+            if (_recoveryTimer >= recoveryStepInterval)
+            {
+                _recoveryTimer = 0f;
+                bool atMax = StepQualityUp();
+
+                if (atMax)
+                {
+                    _recovering = false;
+                    Debug.Log("[QualityScaler] Quality fully restored to baseline.");
+                }
+            }
+        }
+
+        private void OnDestroy()
+        {
+            if (_monitor != null)
+            {
+                _monitor.OnPerformanceDrop    -= HandlePerformanceDrop;
+                _monitor.OnPerformanceRecover -= HandlePerformanceRecover;
+            }
+        }
+
+        // ── Event handlers ───────────────────────────────────────────────────
+
+        private void HandlePerformanceDrop(float avgFps)
+        {
+            _recovering = false; // Stop recovery if we're dropping again.
+            StepQualityDown();
+        }
+
+        private void HandlePerformanceRecover(float avgFps)
+        {
+            // Start gradual recovery (stepped in Update).
+            _recovering    = true;
+            _recoveryTimer = 0f;
+            Debug.Log("[QualityScaler] Starting quality recovery...");
+        }
+
+        // ── Quality stepping ─────────────────────────────────────────────────
+
+        /// <summary>Reduce all quality axes by one step. Returns true if already at minimum.</summary>
+        private bool StepQualityDown()
+        {
+            bool alreadyMin = true;
+
+            // Render scale
+            if (_currentRenderScale > minRenderScale + 0.001f)
+            {
+                _currentRenderScale = Mathf.Max(minRenderScale, _currentRenderScale - renderScaleStep);
+                XRSettings.eyeTextureResolutionScale = _currentRenderScale;
+                alreadyMin = false;
+            }
+
+            // Shadow distance
+            if (_currentShadowDistance > minShadowDistance + 0.001f)
+            {
+                _currentShadowDistance = Mathf.Max(minShadowDistance, _currentShadowDistance - shadowStep);
+                QualitySettings.shadowDistance = _currentShadowDistance;
+                alreadyMin = false;
+            }
+
+            // LOD bias
+            if (_currentLodBias > minLodBias + 0.001f)
+            {
+                _currentLodBias = Mathf.Max(minLodBias, _currentLodBias - lodBiasStep);
+                QualitySettings.lodBias = _currentLodBias;
+                alreadyMin = false;
+            }
+
+            LogCurrentSettings("DOWN");
+            return alreadyMin;
+        }
+
+        /// <summary>Restore all quality axes by one step. Returns true if all at maximum.</summary>
+        private bool StepQualityUp()
+        {
+            bool atMax = true;
+
+            // Render scale
+            if (_currentRenderScale < maxRenderScale - 0.001f)
+            {
+                _currentRenderScale = Mathf.Min(maxRenderScale, _currentRenderScale + renderScaleStep);
+                XRSettings.eyeTextureResolutionScale = _currentRenderScale;
+                atMax = false;
+            }
+
+            // Shadow distance
+            if (_currentShadowDistance < maxShadowDistance - 0.001f)
+            {
+                _currentShadowDistance = Mathf.Min(maxShadowDistance, _currentShadowDistance + shadowStep);
+                QualitySettings.shadowDistance = _currentShadowDistance;
+                atMax = false;
+            }
+
+            // LOD bias
+            if (_currentLodBias < maxLodBias - 0.001f)
+            {
+                _currentLodBias = Mathf.Min(maxLodBias, _currentLodBias + lodBiasStep);
+                QualitySettings.lodBias = _currentLodBias;
+                atMax = false;
+            }
+
+            LogCurrentSettings("UP");
+            return atMax;
+        }
+
+        private void LogCurrentSettings(string direction)
+        {
+            Debug.Log($"[QualityScaler] Step {direction} -- " +
+                      $"renderScale={_currentRenderScale:F2}  " +
+                      $"shadowDist={_currentShadowDistance:F1}  " +
+                      $"lodBias={_currentLodBias:F2}");
+        }
+
+        // ── Editor helper: force reset to baseline ───────────────────────────
+
+        /// <summary>
+        /// Immediately restore all quality settings to their configured max values.
+        /// Useful from editor scripts or debug menus.
+        /// </summary>
+        public void ResetToBaseline()
+        {
+            _recovering = false;
+
+            _currentRenderScale    = maxRenderScale;
+            _currentShadowDistance = maxShadowDistance;
+            _currentLodBias        = maxLodBias;
+
+            XRSettings.eyeTextureResolutionScale = _currentRenderScale;
+            QualitySettings.shadowDistance       = _currentShadowDistance;
+            QualitySettings.lodBias              = _currentLodBias;
+
+            Debug.Log("[QualityScaler] Baseline restored.");
+        }
+    }
+}

--- a/Assets/Scripts/Performance/QualityScaler.cs.meta
+++ b/Assets/Scripts/Performance/QualityScaler.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f985fd53764b4bd2ac516924cc1ef399
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Performance/SpaceWarpManager.cs
+++ b/Assets/Scripts/Performance/SpaceWarpManager.cs
@@ -1,0 +1,177 @@
+// SpaceWarpManager.cs
+// CYBERNOMAD -- Application SpaceWarp controller for Meta Quest 3.
+// Enables ASW (render every 2nd frame, extrapolate motion) to double effective GPU budget.
+// Auto-toggle: monitors FPS, enables ASW when FPS drops below fpsThreshold.
+// Manual override available via SetSpaceWarp(bool).
+//
+// Requires: Vulkan graphics API + Meta XR SDK (HAS_META_XR define).
+// Reference: https://developers.meta.com/horizon/documentation/unity/unity-asw/
+
+using UnityEngine;
+
+namespace Plaga44.Performance
+{
+    /// <summary>
+    /// Singleton MonoBehaviour that controls Application SpaceWarp on Meta Quest.
+    /// Attach to a persistent GameObject in your main scene (e.g. [Performance] root).
+    /// </summary>
+    public class SpaceWarpManager : MonoBehaviour
+    {
+        // ── Singleton ────────────────────────────────────────────────────────
+
+        private static SpaceWarpManager _instance;
+
+        public static SpaceWarpManager Instance => _instance;
+
+        // ── Inspector config ─────────────────────────────────────────────────
+
+        [Header("Auto-Toggle Settings")]
+        [Tooltip("FPS threshold below which ASW is automatically enabled.")]
+        [Range(30f, 90f)]
+        public float fpsThreshold = 65f;
+
+        [Tooltip("Enable Application SpaceWarp automatically on Start.")]
+        public bool enableOnStart = false;
+
+        [Tooltip("Seconds to wait between auto-toggle evaluations (avoids flicker).")]
+        [Range(0.5f, 5f)]
+        public float evaluationInterval = 1.5f;
+
+        [Header("Manual Override")]
+        [Tooltip("When true, auto-toggle is disabled and the state is fully controlled via SetSpaceWarp().")]
+        public bool manualOverride = false;
+
+        // ── Internal state ───────────────────────────────────────────────────
+
+        private bool _isSpaceWarpActive = false;
+        private float _evaluationTimer = 0f;
+
+        // Rolling FPS average over the last evaluationInterval seconds.
+        private float _fpsAccumulator = 0f;
+        private int _fpsFrames = 0;
+        private float _averageFps = 0f;
+
+        // ── Properties ───────────────────────────────────────────────────────
+
+        /// <summary>Current SpaceWarp state (read-only from outside).</summary>
+        public bool IsSpaceWarpActive => _isSpaceWarpActive;
+
+        /// <summary>Last computed average FPS (over evaluationInterval).</summary>
+        public float AverageFps => _averageFps;
+
+        // ── Unity lifecycle ──────────────────────────────────────────────────
+
+        private void Awake()
+        {
+            if (_instance != null && _instance != this)
+            {
+                Debug.LogWarning("[SpaceWarpManager] Duplicate instance destroyed.");
+                Destroy(gameObject);
+                return;
+            }
+
+            _instance = this;
+            DontDestroyOnLoad(gameObject);
+        }
+
+        private void Start()
+        {
+            ValidateVulkan();
+
+            if (enableOnStart)
+                SetSpaceWarp(true);
+        }
+
+        private void Update()
+        {
+            // Accumulate FPS samples.
+            if (Time.unscaledDeltaTime > 0f)
+            {
+                _fpsAccumulator += 1f / Time.unscaledDeltaTime;
+                _fpsFrames++;
+            }
+
+            _evaluationTimer += Time.unscaledDeltaTime;
+
+            if (_evaluationTimer >= evaluationInterval)
+            {
+                _averageFps = (_fpsFrames > 0) ? (_fpsAccumulator / _fpsFrames) : 0f;
+                _fpsAccumulator = 0f;
+                _fpsFrames = 0;
+                _evaluationTimer = 0f;
+
+                if (!manualOverride)
+                    EvaluateAutoToggle();
+            }
+        }
+
+        private void OnDestroy()
+        {
+            if (_instance == this)
+            {
+                // Always disable ASW on cleanup so we don't leave the runtime in an unexpected state.
+                ApplySpaceWarp(false);
+                _instance = null;
+            }
+        }
+
+        // ── Public API ───────────────────────────────────────────────────────
+
+        /// <summary>
+        /// Manually set SpaceWarp state. Activates manualOverride automatically.
+        /// </summary>
+        public void SetSpaceWarp(bool enabled)
+        {
+            manualOverride = true;
+            ApplySpaceWarp(enabled);
+        }
+
+        /// <summary>
+        /// Release manual override and return to auto-toggle mode.
+        /// </summary>
+        public void ReleaseManualOverride()
+        {
+            manualOverride = false;
+        }
+
+        // ── Internal ─────────────────────────────────────────────────────────
+
+        private void EvaluateAutoToggle()
+        {
+            bool shouldEnable = _averageFps < fpsThreshold;
+
+            if (shouldEnable != _isSpaceWarpActive)
+            {
+                Debug.Log($"[SpaceWarpManager] Auto-toggle: avgFPS={_averageFps:F1} threshold={fpsThreshold} -> ASW {(shouldEnable ? "ON" : "OFF")}");
+                ApplySpaceWarp(shouldEnable);
+            }
+        }
+
+        private void ApplySpaceWarp(bool enabled)
+        {
+            if (_isSpaceWarpActive == enabled) return;
+
+            _isSpaceWarpActive = enabled;
+
+#if HAS_META_XR
+            OVRManager.SetSpaceWarp(enabled
+                ? OVRManager.SpaceWarpKeyword.MotionVectorDepth
+                : OVRManager.SpaceWarpKeyword.Disabled);
+
+            Debug.Log($"[SpaceWarpManager] Application SpaceWarp {(enabled ? "ENABLED" : "DISABLED")}");
+#else
+            Debug.Log($"[SpaceWarpManager] HAS_META_XR not defined -- SpaceWarp is a no-op.");
+#endif
+        }
+
+        private void ValidateVulkan()
+        {
+#if UNITY_ANDROID && !UNITY_EDITOR
+            if (SystemInfo.graphicsDeviceType != UnityEngine.Rendering.GraphicsDeviceType.Vulkan)
+            {
+                Debug.LogWarning("[SpaceWarpManager] Application SpaceWarp requires Vulkan. Current API: " + SystemInfo.graphicsDeviceType);
+            }
+#endif
+        }
+    }
+}

--- a/Assets/Scripts/Performance/SpaceWarpManager.cs.meta
+++ b/Assets/Scripts/Performance/SpaceWarpManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4eb9a5b74bc843b2aad07d9a449ff3c4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary

Closes #44

- **SpaceWarpManager** -- singleton that wraps `OVRManager.SetSpaceWarp()`. Auto-enables ASW when rolling-average FPS drops below configurable `fpsThreshold` (default 65 fps). Manual override via `SetSpaceWarp(bool)` / `ReleaseManualOverride()`. Validates Vulkan on device.
- **PerformanceMonitor** -- samples FPS every frame, computes rolling average over `sampleInterval`. Reads `OVRPlugin.gpuUtilLevel` / `OVRPlugin.cpuLevel` when Meta XR is present. Fires `OnPerformanceDrop` / `OnPerformanceRecover` with hysteresis. Toggleable world-space HUD overlay showing FPS, GPU/CPU level, ASW state.
- **QualityScaler** -- subscribes to PerformanceMonitor events. On drop: steps down render scale (`XRSettings.eyeTextureResolutionScale`), shadow distance, and LOD bias. On recover: gradually restores quality one step every `recoveryStepInterval` seconds. `ResetToBaseline()` for editor/debug use.

All files in `Assets/Scripts/Performance/`, namespace `Plaga44.Performance`, `#if HAS_META_XR` guarded throughout.

## Test plan

- [ ] Open Unity 6000.3.7f1, wait for script compilation -- no errors in Console
- [ ] Create empty GameObject `[Performance]` in testbed scene
- [ ] Add **SpaceWarpManager**: Inspector shows `fpsThreshold=65`, `enableOnStart`, `manualOverride` fields
- [ ] Add **PerformanceMonitor** + **QualityScaler** to same GameObject
- [ ] Enter Play mode -- no null ref errors
- [ ] PerformanceMonitor: call `monitor.ToggleHud()` from a test script -- HUD appears in front of camera showing FPS/GPU/CPU/ASW rows
- [ ] QualityScaler: in inspector temporarily set `dropThreshold=200` on PerformanceMonitor so drop fires immediately -- confirm Console logs `[QualityScaler] Step DOWN` and `[SpaceWarpManager]` entries
- [ ] Build for Quest 3 (Android ARM64 IL2CPP) -- no compile errors. With `HAS_META_XR` defined: `OVRManager.SetSpaceWarp` is called. Without define: graceful no-op logged.