### PR TITLE
feat: ISDK Locomotion -- smooth, teleport, body tracking zones (#42)

### DIFF
--- a/Assets/Scripts/Locomotion/BodyTrackingZone.cs
+++ b/Assets/Scripts/Locomotion/BodyTrackingZone.cs
@@ -1,0 +1,146 @@
+using System;
+using UnityEngine;
+
+namespace Plaga44.Locomotion
+{
+    /// <summary>
+    /// Trigger volume that disables controller-based locomotion and activates
+    /// room-scale body tracking mode while the player is physically inside.
+    ///
+    /// Setup:
+    ///   1. Add this component to any GameObject that has a Trigger Collider.
+    ///   2. The VR rig root must have a <see cref="LocomotionManager"/> somewhere
+    ///      in the scene (found automatically at Start).
+    ///   3. The player's tracking origin should be tagged "Player" (configurable).
+    ///
+    /// When the player enters the zone:
+    ///   - <see cref="LocomotionManager"/> switches to RoomScale mode.
+    ///   - <see cref="OnEnterZone"/> event fires.
+    ///
+    /// When the player exits:
+    ///   - <see cref="LocomotionManager"/> reverts to the previous mode.
+    ///   - <see cref="OnExitZone"/> event fires.
+    /// </summary>
+    [RequireComponent(typeof(Collider))]
+    public class BodyTrackingZone : MonoBehaviour
+    {
+        // -------------------------------------------------------------------------
+        // Inspector fields
+        // -------------------------------------------------------------------------
+
+        [Header("Player Detection")]
+        [Tooltip("Tag used to identify the player's collider. Must match the VR rig's tag.")]
+        public string playerTag = "Player";
+
+        [Header("Mode Restore")]
+        [Tooltip("Locomotion mode to restore when the player leaves the zone.")]
+        public LocomotionManager.LocomotionMode exitMode = LocomotionManager.LocomotionMode.SmoothLocomotion;
+
+        [Header("Zone Identity")]
+        [Tooltip("Optional human-readable name for this zone (used in logs and events).")]
+        public string zoneName = "BodyTrackingZone";
+
+        // -------------------------------------------------------------------------
+        // Events
+        // -------------------------------------------------------------------------
+
+        /// <summary>
+        /// Fired when the player enters the zone. Argument is this zone's <see cref="zoneName"/>.
+        /// </summary>
+        public event Action<string> OnEnterZone;
+
+        /// <summary>
+        /// Fired when the player exits the zone. Argument is this zone's <see cref="zoneName"/>.
+        /// </summary>
+        public event Action<string> OnExitZone;
+
+        // -------------------------------------------------------------------------
+        // Runtime state
+        // -------------------------------------------------------------------------
+
+        private LocomotionManager _manager;
+        private bool _playerInside;
+
+        // -------------------------------------------------------------------------
+        // Unity lifecycle
+        // -------------------------------------------------------------------------
+
+        private void Awake()
+        {
+            // Ensure the collider is a trigger.
+            var col = GetComponent<Collider>();
+            if (!col.isTrigger)
+            {
+                Debug.LogWarning($"[BodyTrackingZone] '{zoneName}': Collider is not a trigger. Forcing isTrigger = true.");
+                col.isTrigger = true;
+            }
+        }
+
+        private void Start()
+        {
+            _manager = FindFirstObjectByType<LocomotionManager>();
+
+            if (_manager == null)
+                Debug.LogWarning($"[BodyTrackingZone] '{zoneName}': No LocomotionManager found in scene. Zone events will still fire but mode won't switch.");
+        }
+
+        private void OnTriggerEnter(Collider other)
+        {
+            if (!other.CompareTag(playerTag)) return;
+            if (_playerInside) return;
+
+            _playerInside = true;
+
+            Debug.Log($"[BodyTrackingZone] Player entered zone '{zoneName}' -- switching to RoomScale.");
+
+            _manager?.SetMode(LocomotionManager.LocomotionMode.RoomScale);
+            OnEnterZone?.Invoke(zoneName);
+        }
+
+        private void OnTriggerExit(Collider other)
+        {
+            if (!other.CompareTag(playerTag)) return;
+            if (!_playerInside) return;
+
+            _playerInside = false;
+
+            Debug.Log($"[BodyTrackingZone] Player exited zone '{zoneName}' -- restoring mode {exitMode}.");
+
+            _manager?.SetMode(exitMode);
+            OnExitZone?.Invoke(zoneName);
+        }
+
+        // -------------------------------------------------------------------------
+        // Debug visualisation
+        // -------------------------------------------------------------------------
+
+        private void OnDrawGizmos()
+        {
+            var col = GetComponent<Collider>();
+            if (col == null) return;
+
+            Gizmos.color = _playerInside
+                ? new Color(0f, 1f, 0f, 0.35f)
+                : new Color(0f, 0.6f, 1f, 0.25f);
+
+            if (col is BoxCollider box)
+            {
+                Matrix4x4 old = Gizmos.matrix;
+                Gizmos.matrix = Matrix4x4.TRS(transform.position, transform.rotation, transform.lossyScale);
+                Gizmos.DrawCube(box.center, box.size);
+                Gizmos.DrawWireCube(box.center, box.size);
+                Gizmos.matrix = old;
+            }
+            else if (col is SphereCollider sphere)
+            {
+                Gizmos.DrawSphere(transform.TransformPoint(sphere.center),
+                                  sphere.radius * Mathf.Max(transform.lossyScale.x,
+                                                            transform.lossyScale.z));
+            }
+
+#if UNITY_EDITOR
+            UnityEditor.Handles.Label(transform.position + Vector3.up * 0.1f, zoneName);
+#endif
+        }
+    }
+}

--- a/Assets/Scripts/Locomotion/ComfortVignette.cs
+++ b/Assets/Scripts/Locomotion/ComfortVignette.cs
@@ -1,0 +1,242 @@
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace Plaga44.Locomotion
+{
+    /// <summary>
+    /// Screen-space vignette overlay that reduces motion sickness during smooth locomotion.
+    ///
+    /// Renders a fullscreen Canvas Image with a radial gradient material.
+    /// Intensity (vignette radius) scales with the player's current movement speed
+    /// sourced from <see cref="SmoothLocomotion.NormalisedSpeed"/>.
+    ///
+    /// Setup options:
+    ///   A) Auto-setup: leave all serialized references null -- the component will
+    ///      create a Canvas + RawImage at runtime using a programmatic texture.
+    ///   B) Manual: provide your own Canvas and a Material based on a vignette shader.
+    ///      Set <see cref="vignetteImage"/> and optionally <see cref="vignetteIntensityParam"/>.
+    ///
+    /// Attach to the same GameObject as (or a child of) the VR rig root.
+    /// <see cref="LocomotionManager"/> enables/disables this component automatically.
+    /// </summary>
+    [DisallowMultipleComponent]
+    public class ComfortVignette : MonoBehaviour
+    {
+        // -------------------------------------------------------------------------
+        // Inspector fields
+        // -------------------------------------------------------------------------
+
+        [Header("Intensity Mapping")]
+        [Tooltip("Vignette intensity at maximum movement speed (0 = invisible, 1 = full black).")]
+        [Range(0f, 1f)]
+        public float maxIntensity = 0.6f;
+
+        [Tooltip("Threshold of normalised speed below which the vignette starts fading in.")]
+        [Range(0f, 1f)]
+        public float fadeInThreshold = 0.05f;
+
+        [Tooltip("Speed of intensity lerp. Higher = faster response.")]
+        public float lerpSpeed = 8f;
+
+        [Header("Colour")]
+        [Tooltip("Vignette colour. Typically black.")]
+        public Color vignetteColor = Color.black;
+
+        [Header("Manual References (optional)")]
+        [Tooltip("RawImage or Image used as the vignette overlay. Auto-created if null.")]
+        [SerializeField] private Graphic vignetteImage;
+
+        [Tooltip("If using a custom Material with an intensity parameter, enter the shader property name here.")]
+        [SerializeField] private string vignetteIntensityParam = "_Intensity";
+
+        // -------------------------------------------------------------------------
+        // Runtime state
+        // -------------------------------------------------------------------------
+
+        private SmoothLocomotion _locomotion;
+        private float _currentIntensity;
+        private bool _useMaterialParam;
+        private bool _useAlpha;          // fallback: drive intensity via image alpha
+        private Texture2D _vignetteTexture;
+
+        // -------------------------------------------------------------------------
+        // Unity lifecycle
+        // -------------------------------------------------------------------------
+
+        private void Awake()
+        {
+            _locomotion = GetComponentInParent<SmoothLocomotion>(includeInactive: true);
+
+            if (vignetteImage == null)
+                CreateFallbackOverlay();
+            else
+                DetermineRenderMode();
+        }
+
+        private void OnEnable()
+        {
+            // Reset intensity visually when re-enabled.
+            ApplyIntensityImmediate(0f);
+        }
+
+        private void OnDisable()
+        {
+            ApplyIntensityImmediate(0f);
+        }
+
+        private void Update()
+        {
+            float targetIntensity = 0f;
+
+            if (_locomotion != null)
+            {
+                float speed = _locomotion.NormalisedSpeed;
+                if (speed > fadeInThreshold)
+                    targetIntensity = Mathf.InverseLerp(fadeInThreshold, 1f, speed) * maxIntensity;
+            }
+
+            _currentIntensity = Mathf.Lerp(_currentIntensity, targetIntensity, Time.deltaTime * lerpSpeed);
+            ApplyIntensityImmediate(_currentIntensity);
+        }
+
+        // -------------------------------------------------------------------------
+        // Public API
+        // -------------------------------------------------------------------------
+
+        /// <summary>Directly set vignette intensity (used by LocomotionManager to clear on mode switch).</summary>
+        public void SetIntensity(float intensity)
+        {
+            _currentIntensity = intensity;
+            ApplyIntensityImmediate(intensity);
+        }
+
+        // -------------------------------------------------------------------------
+        // Internal
+        // -------------------------------------------------------------------------
+
+        private void ApplyIntensityImmediate(float intensity)
+        {
+            if (vignetteImage == null) return;
+
+            if (_useMaterialParam && vignetteImage.material != null)
+            {
+                vignetteImage.material.SetFloat(vignetteIntensityParam, intensity);
+            }
+            else if (_useAlpha)
+            {
+                Color c = vignetteColor;
+                c.a = intensity;
+                vignetteImage.color = c;
+            }
+        }
+
+        private void DetermineRenderMode()
+        {
+            if (vignetteImage != null
+                && vignetteImage.material != null
+                && vignetteImage.material.HasProperty(vignetteIntensityParam))
+            {
+                _useMaterialParam = true;
+            }
+            else
+            {
+                _useAlpha = true;
+            }
+        }
+
+        /// <summary>
+        /// Creates a fullscreen Canvas with a programmatic radial gradient texture
+        /// when no manual references are provided.
+        /// </summary>
+        private void CreateFallbackOverlay()
+        {
+            // Find or create a ScreenSpaceOverlay Canvas that lives under VR camera.
+            // Note: in VR ScreenSpaceOverlay is not correct; we need World Space or Camera Space.
+            // We use Camera Space here so it moves with the HMD.
+
+            Transform headTransform = null;
+
+#if HAS_META_XR
+            var tracking = transform.root.Find("TrackingSpace");
+            if (tracking != null)
+                headTransform = tracking.Find("CenterEyeAnchor");
+#endif
+            if (headTransform == null && Camera.main != null)
+                headTransform = Camera.main.transform;
+
+            // Build Canvas.
+            var canvasGO = new GameObject("ComfortVignetteCanvas");
+            canvasGO.transform.SetParent(headTransform != null ? headTransform : transform, false);
+
+            var canvas = canvasGO.AddComponent<Canvas>();
+            canvas.renderMode = RenderMode.WorldSpace;
+
+            // Position just in front of the camera -- distance chosen so it fills view.
+            canvasGO.transform.localPosition = new Vector3(0f, 0f, 0.31f);
+            canvasGO.transform.localRotation = Quaternion.identity;
+
+            // Size to fill ~110 deg FOV at 0.31 m distance (Quest 3 FOV approx).
+            float halfSize = Mathf.Tan(55f * Mathf.Deg2Rad) * 0.31f;
+            var rt = canvasGO.GetComponent<RectTransform>();
+            rt.sizeDelta = new Vector2(halfSize * 2f, halfSize * 2f);
+
+            canvasGO.AddComponent<CanvasGroup>().blocksRaycasts = false;
+
+            // Build Image.
+            var imgGO = new GameObject("VignetteImage");
+            imgGO.transform.SetParent(canvasGO.transform, false);
+
+            var imgRt = imgGO.AddComponent<RectTransform>();
+            imgRt.anchorMin = Vector2.zero;
+            imgRt.anchorMax = Vector2.one;
+            imgRt.offsetMin = Vector2.zero;
+            imgRt.offsetMax = Vector2.zero;
+
+            var rawImg = imgGO.AddComponent<RawImage>();
+            rawImg.raycastTarget = false;
+
+            // Generate radial gradient texture.
+            _vignetteTexture = GenerateVignetteTexture(128);
+            rawImg.texture = _vignetteTexture;
+
+            Color c = vignetteColor;
+            c.a = 0f;
+            rawImg.color = c;
+
+            vignetteImage = rawImg;
+            _useAlpha = true;
+        }
+
+        private Texture2D GenerateVignetteTexture(int size)
+        {
+            var tex = new Texture2D(size, size, TextureFormat.RGBA32, mipChain: false);
+            tex.wrapMode = TextureWrapMode.Clamp;
+
+            float center = size * 0.5f;
+            float radius = center;
+
+            for (int y = 0; y < size; y++)
+            {
+                for (int x = 0; x < size; x++)
+                {
+                    float dx = (x - center) / radius;
+                    float dy = (y - center) / radius;
+                    float dist = Mathf.Sqrt(dx * dx + dy * dy);
+
+                    // Smooth step: transparent in centre, opaque at edges.
+                    float alpha = Mathf.SmoothStep(0.4f, 1.0f, dist);
+                    tex.SetPixel(x, y, new Color(0f, 0f, 0f, alpha));
+                }
+            }
+
+            tex.Apply();
+            return tex;
+        }
+
+        private void OnDestroy()
+        {
+            if (_vignetteTexture != null)
+                Destroy(_vignetteTexture);
+        }
+    }
+}

--- a/Assets/Scripts/Locomotion/LocomotionManager.cs
+++ b/Assets/Scripts/Locomotion/LocomotionManager.cs
@@ -1,0 +1,174 @@
+using System;
+using UnityEngine;
+
+// HAS_META_XR is defined in ProjectSettings > Player > Scripting Define Symbols
+// when Meta XR SDK Core is present. Sub-systems use it internally; LocomotionManager
+// only orchestrates them and requires no direct OVR calls.
+
+namespace Plaga44.Locomotion
+{
+    /// <summary>
+    /// Central manager for all locomotion modes in PLAGA '44.
+    /// Switches between SmoothLocomotion, TeleportLocomotion, and RoomScale (body tracking).
+    /// Attach to the VR rig root GameObject alongside OVRCameraRig (Meta) or XROrigin (Unity XR).
+    /// </summary>
+    public class LocomotionManager : MonoBehaviour
+    {
+        // -------------------------------------------------------------------------
+        // Enums
+        // -------------------------------------------------------------------------
+
+        public enum LocomotionMode
+        {
+            SmoothLocomotion,
+            Teleport,
+            RoomScale
+        }
+
+        public enum TurnMode
+        {
+            Snap,
+            Smooth
+        }
+
+        // -------------------------------------------------------------------------
+        // Inspector fields
+        // -------------------------------------------------------------------------
+
+        [Header("Active Mode")]
+        [Tooltip("Starting locomotion mode. Can be changed at runtime via SetMode().")]
+        [SerializeField] private LocomotionMode _startMode = LocomotionMode.SmoothLocomotion;
+
+        [Header("Movement Config")]
+        [Tooltip("Walk speed in metres per second (SmoothLocomotion).")]
+        [SerializeField] public float moveSpeed = 2.5f;
+
+        [Tooltip("Snap turn angle in degrees, or smooth turn speed deg/sec.")]
+        [SerializeField] public float turnSpeed = 45f;
+
+        [SerializeField] public TurnMode turnMode = TurnMode.Snap;
+
+        [Header("Comfort Vignette")]
+        [SerializeField] private bool _enableVignette = true;
+
+        [Header("Component References (auto-found if null)")]
+        [SerializeField] private SmoothLocomotion _smoothLocomotion;
+        [SerializeField] private TeleportLocomotion _teleportLocomotion;
+        [SerializeField] private ComfortVignette _comfortVignette;
+
+        // -------------------------------------------------------------------------
+        // Runtime state
+        // -------------------------------------------------------------------------
+
+        private LocomotionMode _currentMode;
+
+        // -------------------------------------------------------------------------
+        // Events
+        // -------------------------------------------------------------------------
+
+        /// <summary>Fired when the active locomotion mode changes.</summary>
+        public event Action<LocomotionMode> OnModeChanged;
+
+        // -------------------------------------------------------------------------
+        // Unity lifecycle
+        // -------------------------------------------------------------------------
+
+        private void Awake()
+        {
+            GatherComponents();
+            ApplyMode(_startMode, force: true);
+        }
+
+        private void Start()
+        {
+            // Propagate inspector config to sub-systems after all Awakes have run.
+            PushConfigToSubSystems();
+        }
+
+        // -------------------------------------------------------------------------
+        // Public API
+        // -------------------------------------------------------------------------
+
+        /// <summary>Returns the currently active locomotion mode.</summary>
+        public LocomotionMode CurrentMode => _currentMode;
+
+        /// <summary>
+        /// Switches to the given locomotion mode.
+        /// RoomScale is typically activated automatically by <see cref="BodyTrackingZone"/>.
+        /// </summary>
+        public void SetMode(LocomotionMode mode)
+        {
+            if (mode == _currentMode) return;
+            ApplyMode(mode, force: false);
+        }
+
+        /// <summary>Re-applies current config values to sub-systems (call after changing fields at runtime).</summary>
+        public void RefreshConfig()
+        {
+            PushConfigToSubSystems();
+        }
+
+        // -------------------------------------------------------------------------
+        // Internal helpers
+        // -------------------------------------------------------------------------
+
+        private void GatherComponents()
+        {
+            if (_smoothLocomotion == null)
+                _smoothLocomotion = GetComponentInChildren<SmoothLocomotion>(includeInactive: true);
+
+            if (_teleportLocomotion == null)
+                _teleportLocomotion = GetComponentInChildren<TeleportLocomotion>(includeInactive: true);
+
+            if (_comfortVignette == null)
+                _comfortVignette = GetComponentInChildren<ComfortVignette>(includeInactive: true);
+        }
+
+        private void ApplyMode(LocomotionMode mode, bool force)
+        {
+            if (!force && mode == _currentMode) return;
+
+            _currentMode = mode;
+
+            bool smooth    = (mode == LocomotionMode.SmoothLocomotion);
+            bool teleport  = (mode == LocomotionMode.Teleport);
+            bool roomScale = (mode == LocomotionMode.RoomScale);
+
+            SetEnabled(_smoothLocomotion,   smooth);
+            SetEnabled(_teleportLocomotion, teleport);
+
+            // Vignette only makes sense during smooth locomotion.
+            if (_comfortVignette != null)
+            {
+                _comfortVignette.enabled = _enableVignette && smooth;
+                if (!smooth) _comfortVignette.SetIntensity(0f);
+            }
+
+            if (roomScale)
+            {
+                Debug.Log("[LocomotionManager] RoomScale active -- controller locomotion disabled.");
+            }
+
+            OnModeChanged?.Invoke(mode);
+            Debug.Log($"[LocomotionManager] Mode -> {mode}");
+        }
+
+        private void PushConfigToSubSystems()
+        {
+            if (_smoothLocomotion != null)
+            {
+                _smoothLocomotion.moveSpeed = moveSpeed;
+                _smoothLocomotion.turnSpeed = turnSpeed;
+                _smoothLocomotion.snapTurns = (turnMode == TurnMode.Snap);
+            }
+
+            if (_comfortVignette != null)
+                _comfortVignette.enabled = _enableVignette && (_currentMode == LocomotionMode.SmoothLocomotion);
+        }
+
+        private static void SetEnabled(MonoBehaviour mb, bool state)
+        {
+            if (mb != null) mb.enabled = state;
+        }
+    }
+}

--- a/Assets/Scripts/Locomotion/SmoothLocomotion.cs
+++ b/Assets/Scripts/Locomotion/SmoothLocomotion.cs
@@ -1,0 +1,210 @@
+using UnityEngine;
+
+#if HAS_META_XR
+// OVRInput is available from Meta XR SDK Core.
+#elif UNITY_XR
+using UnityEngine.XR;
+#endif
+
+namespace Plaga44.Locomotion
+{
+    /// <summary>
+    /// Thumbstick-driven smooth locomotion.
+    ///
+    /// Movement direction is relative to headset forward (horizontal plane only).
+    /// Left thumbstick: move forward/back/strafe.
+    /// Right thumbstick: turn (snap or smooth, configured by <see cref="snapTurns"/>).
+    ///
+    /// Requires the rig root (OVRCameraRig / XROrigin) as the transform that gets moved.
+    /// The headset camera transform must be reachable via <see cref="_headTransform"/>.
+    /// </summary>
+    [DisallowMultipleComponent]
+    public class SmoothLocomotion : MonoBehaviour
+    {
+        // -------------------------------------------------------------------------
+        // Inspector fields
+        // -------------------------------------------------------------------------
+
+        [Header("Speed")]
+        [Tooltip("Walk speed in metres per second.")]
+        public float moveSpeed = 2.5f;
+
+        [Tooltip("Strafe speed multiplier relative to forward speed.")]
+        [Range(0.1f, 1f)]
+        public float strafeFactor = 0.8f;
+
+        [Header("Turn")]
+        [Tooltip("True = snap turn by snapAngle. False = smooth turn at turnSpeed deg/sec.")]
+        public bool snapTurns = true;
+
+        [Tooltip("Degrees per snap turn step.")]
+        public float snapAngle = 45f;
+
+        [Tooltip("Smooth turn speed in degrees per second (used when snapTurns = false).")]
+        public float turnSpeed = 90f;
+
+        [Tooltip("Deadzone for thumbstick turn input to prevent drift.")]
+        [Range(0.1f, 0.9f)]
+        public float turnDeadzone = 0.5f;
+
+        [Header("Head Reference")]
+        [Tooltip("Camera / center-eye transform. Populated automatically from OVRCameraRig or Camera.main.")]
+        [SerializeField] private Transform _headTransform;
+
+        // -------------------------------------------------------------------------
+        // Runtime state
+        // -------------------------------------------------------------------------
+
+        private float _snapCooldown;
+        private const float SnapCooldownDuration = 0.25f;
+
+        // Smooth-turn state
+        private bool _turnReleased = true;
+
+        // -------------------------------------------------------------------------
+        // Events
+        // -------------------------------------------------------------------------
+
+        /// <summary>Current normalised speed (0-1). Used by ComfortVignette.</summary>
+        public float NormalisedSpeed { get; private set; }
+
+        // -------------------------------------------------------------------------
+        // Unity lifecycle
+        // -------------------------------------------------------------------------
+
+        private void Awake()
+        {
+            if (_headTransform == null)
+                _headTransform = ResolveHeadTransform();
+        }
+
+        private void Update()
+        {
+            if (_headTransform == null) return;
+
+            Vector2 moveInput = GetMoveInput();
+            Vector2 turnInput = GetTurnInput();
+
+            HandleMovement(moveInput);
+            HandleTurn(turnInput);
+        }
+
+        // -------------------------------------------------------------------------
+        // Input abstraction
+        // -------------------------------------------------------------------------
+
+        private Vector2 GetMoveInput()
+        {
+#if HAS_META_XR
+            return OVRInput.Get(OVRInput.Axis2D.PrimaryThumbstick, OVRInput.Controller.LTouch);
+#else
+            // Unity Input System / legacy fallback.
+            float h = Input.GetAxis("Horizontal");
+            float v = Input.GetAxis("Vertical");
+            return new Vector2(h, v);
+#endif
+        }
+
+        private Vector2 GetTurnInput()
+        {
+#if HAS_META_XR
+            return OVRInput.Get(OVRInput.Axis2D.PrimaryThumbstick, OVRInput.Controller.RTouch);
+#else
+            float turn = Input.GetAxis("RightStickHorizontal");
+            return new Vector2(turn, 0f);
+#endif
+        }
+
+        // -------------------------------------------------------------------------
+        // Movement
+        // -------------------------------------------------------------------------
+
+        private void HandleMovement(Vector2 input)
+        {
+            if (input.sqrMagnitude < 0.01f)
+            {
+                NormalisedSpeed = 0f;
+                return;
+            }
+
+            // Flatten head forward onto horizontal plane.
+            Vector3 fwd = _headTransform.forward;
+            fwd.y = 0f;
+            fwd.Normalize();
+
+            Vector3 right = _headTransform.right;
+            right.y = 0f;
+            right.Normalize();
+
+            Vector3 move = (fwd * input.y) + (right * (input.x * strafeFactor));
+            move *= moveSpeed * Time.deltaTime;
+            move.y = 0f;
+
+            transform.position += move;
+
+            // Report normalised speed for vignette (clamp input magnitude to 1).
+            NormalisedSpeed = Mathf.Clamp01(input.magnitude);
+        }
+
+        // -------------------------------------------------------------------------
+        // Turning
+        // -------------------------------------------------------------------------
+
+        private void HandleTurn(Vector2 input)
+        {
+            if (snapTurns)
+                HandleSnapTurn(input);
+            else
+                HandleSmoothTurn(input);
+        }
+
+        private void HandleSnapTurn(Vector2 input)
+        {
+            _snapCooldown -= Time.deltaTime;
+
+            if (Mathf.Abs(input.x) > turnDeadzone && _snapCooldown <= 0f)
+            {
+                float dir = Mathf.Sign(input.x);
+                transform.Rotate(0f, dir * snapAngle, 0f, Space.World);
+                _snapCooldown = SnapCooldownDuration;
+            }
+        }
+
+        private void HandleSmoothTurn(Vector2 input)
+        {
+            if (Mathf.Abs(input.x) > turnDeadzone)
+            {
+                float rotation = input.x * turnSpeed * Time.deltaTime;
+                transform.Rotate(0f, rotation, 0f, Space.World);
+                _turnReleased = false;
+            }
+            else
+            {
+                _turnReleased = true;
+            }
+        }
+
+        // -------------------------------------------------------------------------
+        // Head transform resolution
+        // -------------------------------------------------------------------------
+
+        private Transform ResolveHeadTransform()
+        {
+#if HAS_META_XR
+            // OVRCameraRig stores CenterEyeAnchor under TrackingSpace.
+            var tracking = transform.Find("TrackingSpace");
+            if (tracking != null)
+            {
+                var eye = tracking.Find("CenterEyeAnchor");
+                if (eye != null) return eye;
+            }
+#endif
+            // Fallback: use the main camera.
+            if (Camera.main != null)
+                return Camera.main.transform;
+
+            Debug.LogWarning("[SmoothLocomotion] Could not find head transform. Assign _headTransform manually.");
+            return null;
+        }
+    }
+}

--- a/Assets/Scripts/Locomotion/TeleportLocomotion.cs
+++ b/Assets/Scripts/Locomotion/TeleportLocomotion.cs
@@ -1,0 +1,280 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace Plaga44.Locomotion
+{
+    /// <summary>
+    /// Thumbstick-triggered teleport locomotion with arc visualizer and landing indicator.
+    ///
+    /// Usage:
+    ///   1. Attach to VR rig root.
+    ///   2. Assign a LineRenderer (or let it auto-create).
+    ///   3. Set <see cref="validLayers"/> to layers the player can land on.
+    ///   4. Aim right thumbstick forward -- arc appears. Release to teleport.
+    ///
+    /// Requires <see cref="LocomotionManager"/> on same/parent GameObject to fire
+    /// the mode switch callback (optional -- works standalone too).
+    /// </summary>
+    [DisallowMultipleComponent]
+    public class TeleportLocomotion : MonoBehaviour
+    {
+        // -------------------------------------------------------------------------
+        // Inspector fields
+        // -------------------------------------------------------------------------
+
+        [Header("Arc")]
+        [Tooltip("Maximum arc travel distance in metres.")]
+        public float maxDistance = 10f;
+
+        [Tooltip("Number of segments in the arc LineRenderer.")]
+        [Range(8, 64)]
+        public int arcResolution = 24;
+
+        [Tooltip("Initial launch speed of the projectile simulation (higher = flatter arc).")]
+        public float arcLaunchSpeed = 8f;
+
+        [Tooltip("Simulated gravity for the arc (downward). Usually 9.81.")]
+        public float arcGravity = 9.81f;
+
+        [Header("Layers")]
+        [Tooltip("LayerMask of surfaces the player is allowed to teleport onto.")]
+        public LayerMask validLayers = ~0;   // default: everything
+
+        [Header("Input")]
+        [Tooltip("Deadzone for the right thumbstick Y axis to activate the arc.")]
+        [Range(0.1f, 0.9f)]
+        public float inputDeadzone = 0.5f;
+
+        [Header("References")]
+        [Tooltip("LineRenderer for the arc. Auto-created if null.")]
+        [SerializeField] private LineRenderer _arcLine;
+
+        [Tooltip("Transform placed at the landing indicator. Auto-created if null.")]
+        [SerializeField] private Transform _landingIndicator;
+
+        [Tooltip("Material used on the arc when landing is valid.")]
+        [SerializeField] private Material _validArcMaterial;
+
+        [Tooltip("Material used on the arc when landing is invalid.")]
+        [SerializeField] private Material _invalidArcMaterial;
+
+        [Header("Head / Hand References")]
+        [SerializeField] private Transform _headTransform;
+        [SerializeField] private Transform _rightHandTransform;
+
+        // -------------------------------------------------------------------------
+        // Runtime state
+        // -------------------------------------------------------------------------
+
+        private bool _aiming;
+        private bool _hasValidTarget;
+        private Vector3 _targetPoint;
+        private readonly List<Vector3> _arcPoints = new List<Vector3>(64);
+
+        // -------------------------------------------------------------------------
+        // Unity lifecycle
+        // -------------------------------------------------------------------------
+
+        private void Awake()
+        {
+            EnsureLineRenderer();
+            EnsureLandingIndicator();
+            ResolveTransforms();
+
+            SetArcVisible(false);
+        }
+
+        private void Update()
+        {
+            Vector2 thumbstick = GetRightThumbstick();
+            bool wantsAim = thumbstick.y > inputDeadzone;
+
+            if (wantsAim)
+            {
+                _aiming = true;
+                UpdateArc();
+            }
+            else if (_aiming)
+            {
+                // Thumbstick released -- attempt teleport.
+                _aiming = false;
+                SetArcVisible(false);
+
+                if (_hasValidTarget)
+                    ExecuteTeleport(_targetPoint);
+            }
+        }
+
+        // -------------------------------------------------------------------------
+        // Input
+        // -------------------------------------------------------------------------
+
+        private Vector2 GetRightThumbstick()
+        {
+#if HAS_META_XR
+            return OVRInput.Get(OVRInput.Axis2D.PrimaryThumbstick, OVRInput.Controller.RTouch);
+#else
+            float h = Input.GetAxis("RightStickHorizontal");
+            float v = Input.GetAxis("RightStickVertical");
+            return new Vector2(h, v);
+#endif
+        }
+
+        // -------------------------------------------------------------------------
+        // Arc calculation
+        // -------------------------------------------------------------------------
+
+        private void UpdateArc()
+        {
+            _arcPoints.Clear();
+
+            Transform origin = _rightHandTransform != null ? _rightHandTransform
+                             : _headTransform != null      ? _headTransform
+                             : transform;
+
+            Vector3 pos = origin.position;
+            Vector3 vel = origin.forward * arcLaunchSpeed;
+
+            float stepTime = maxDistance / (arcResolution * arcLaunchSpeed);
+            _hasValidTarget = false;
+
+            for (int i = 0; i < arcResolution; i++)
+            {
+                _arcPoints.Add(pos);
+
+                Vector3 nextPos = pos + vel * stepTime;
+                vel.y -= arcGravity * stepTime;
+
+                // Check for collision along this segment.
+                Vector3 dir = nextPos - pos;
+                float dist = dir.magnitude;
+
+                if (Physics.Raycast(pos, dir.normalized, out RaycastHit hit, dist, validLayers))
+                {
+                    _arcPoints.Add(hit.point);
+                    _hasValidTarget = true;
+                    _targetPoint = hit.point;
+                    UpdateLandingIndicator(hit.point, valid: true);
+                    break;
+                }
+
+                pos = nextPos;
+
+                // Stop arc if it has gone further than maxDistance.
+                if (Vector3.Distance(origin.position, pos) >= maxDistance)
+                    break;
+            }
+
+            // If no hit found, hide indicator.
+            if (!_hasValidTarget)
+                UpdateLandingIndicator(Vector3.zero, valid: false);
+
+            // Update LineRenderer.
+            _arcLine.positionCount = _arcPoints.Count;
+            _arcLine.SetPositions(_arcPoints.ToArray());
+
+            // Swap material based on validity.
+            if (_validArcMaterial != null && _invalidArcMaterial != null)
+                _arcLine.material = _hasValidTarget ? _validArcMaterial : _invalidArcMaterial;
+
+            SetArcVisible(true);
+        }
+
+        // -------------------------------------------------------------------------
+        // Teleport execution
+        // -------------------------------------------------------------------------
+
+        private void ExecuteTeleport(Vector3 destination)
+        {
+            // Keep the player's height relative to the rig (don't snap Y unless flat surface).
+            Vector3 rigPos = transform.position;
+            destination.y = rigPos.y; // preserve vertical; room-scale handles height.
+
+            transform.position = destination;
+            Debug.Log($"[TeleportLocomotion] Teleported to {destination}");
+        }
+
+        // -------------------------------------------------------------------------
+        // Visuals helpers
+        // -------------------------------------------------------------------------
+
+        private void SetArcVisible(bool visible)
+        {
+            if (_arcLine != null) _arcLine.enabled = visible;
+            if (_landingIndicator != null) _landingIndicator.gameObject.SetActive(visible && _hasValidTarget);
+        }
+
+        private void UpdateLandingIndicator(Vector3 point, bool valid)
+        {
+            if (_landingIndicator == null) return;
+            _landingIndicator.gameObject.SetActive(valid);
+            if (valid) _landingIndicator.position = point;
+        }
+
+        // -------------------------------------------------------------------------
+        // Auto-creation of missing components
+        // -------------------------------------------------------------------------
+
+        private void EnsureLineRenderer()
+        {
+            if (_arcLine != null) return;
+
+            _arcLine = GetComponent<LineRenderer>();
+            if (_arcLine != null) return;
+
+            _arcLine = gameObject.AddComponent<LineRenderer>();
+            _arcLine.widthMultiplier = 0.02f;
+            _arcLine.useWorldSpace = true;
+            _arcLine.receiveShadows = false;
+            _arcLine.shadowCastingMode = UnityEngine.Rendering.ShadowCastingMode.Off;
+
+            // Simple default material (URP unlit white if no material assigned).
+            if (_arcLine.sharedMaterial == null)
+                _arcLine.sharedMaterial = new Material(Shader.Find("Universal Render Pipeline/Unlit")
+                                                    ?? Shader.Find("Sprites/Default"));
+        }
+
+        private void EnsureLandingIndicator()
+        {
+            if (_landingIndicator != null) return;
+
+            GameObject indicator = GameObject.CreatePrimitive(PrimitiveType.Cylinder);
+            indicator.name = "TeleportLandingIndicator";
+            indicator.transform.localScale = new Vector3(0.5f, 0.02f, 0.5f);
+
+            // Remove collider so it doesn't interfere with raycasts.
+            Destroy(indicator.GetComponent<Collider>());
+
+            _landingIndicator = indicator.transform;
+        }
+
+        private void ResolveTransforms()
+        {
+            if (_headTransform == null)
+            {
+#if HAS_META_XR
+                var tracking = transform.Find("TrackingSpace");
+                if (tracking != null)
+                {
+                    var eye = tracking.Find("CenterEyeAnchor");
+                    if (eye != null) _headTransform = eye;
+                }
+#endif
+                if (_headTransform == null && Camera.main != null)
+                    _headTransform = Camera.main.transform;
+            }
+
+            if (_rightHandTransform == null)
+            {
+#if HAS_META_XR
+                var tracking = transform.Find("TrackingSpace");
+                if (tracking != null)
+                {
+                    var hand = tracking.Find("RightHandAnchor");
+                    if (hand != null) _rightHandTransform = hand;
+                }
+#endif
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- **LocomotionManager** (`Assets/Scripts/Locomotion/LocomotionManager.cs`) -- MonoBehaviour orchestrator. Switches between `SmoothLocomotion`, `Teleport`, `RoomScale` modes. Exposes `moveSpeed`, `turnSpeed`, `TurnMode` (snap/smooth), comfort vignette toggle.
- **SmoothLocomotion** (`SmoothLocomotion.cs`) -- thumbstick movement relative to HMD forward (flat plane). Left stick: move + strafe. Right stick: snap or smooth turn with configurable deadzone.
- **TeleportLocomotion** (`TeleportLocomotion.cs`) -- projectile-arc visualizer via `LineRenderer`, valid/invalid landing indicator (`Cylinder` primitive). Thumbstick aim -> release to teleport. Configurable `maxDistance`, `arcResolution`, `validLayers`.
- **BodyTrackingZone** (`BodyTrackingZone.cs`) -- `[RequireComponent(Collider)]` trigger. On player enter: `LocomotionManager.SetMode(RoomScale)` + fires `OnEnterZone` event. On exit: restores configurable `exitMode` + fires `OnExitZone`. Gizmo draw in editor.
- **ComfortVignette** (`ComfortVignette.cs`) -- World-space Canvas vignette overlay. Intensity proportional to `SmoothLocomotion.NormalisedSpeed`. Fallback: auto-generates radial gradient `Texture2D` if no material assigned.

All scripts:
- `namespace Plaga44.Locomotion`
- `#if HAS_META_XR` guards with Unity XR / legacy input fallbacks
- No existing files modified

Closes #42

## Test plan

- [ ] Open a scene with OVRCameraRig (tagged `Player`).
- [ ] Add `LocomotionManager`, `SmoothLocomotion`, `TeleportLocomotion`, `ComfortVignette` to the rig root.
- [ ] **SmoothLocomotion**: Play in editor (with Quest Link or emulator). Left stick -- rig moves forward/strafe relative to HMD. Right stick -- snap turns 45 deg.
- [ ] Change `TurnMode` to `Smooth` in inspector -- right stick should rotate continuously.
- [ ] **TeleportLocomotion**: Hold right thumbstick forward -- arc LineRenderer appears. Release over valid surface -- rig teleports. Aim at invalid layer -- arc material changes (if materials assigned) or indicator hides.
- [ ] **BodyTrackingZone**: Create a box trigger with `BodyTrackingZone` on it. Walk (physically) into trigger -- check Console log "Player entered zone ... switching to RoomScale". SmoothLocomotion disables. Exit zone -- SmoothLocomotion re-enables.
- [ ] **ComfortVignette**: Enable vignette in LocomotionManager inspector. Move with left stick -- vignette darkens at edges. Stop -- fades out.
- [ ] Build Android/ARM64 IL2CPP -- no compile errors with `HAS_META_XR` undefined (fallback path).
- [ ] Define `HAS_META_XR` in Scripting Define Symbols -- rebuild -- OVR input path compiles cleanly.
Closes #42