### PR TITLE
feat: multiplayer networking -- body/face tracking (#43)

### DIFF
--- a/Assets/Scripts/Networking/LobbyUI.cs
+++ b/Assets/Scripts/Networking/LobbyUI.cs
@@ -1,0 +1,659 @@
+// LobbyUI.cs
+// CYBERNOMAD -- PLAGA '44
+// World-space lobby UI: Create/Join room, player list, ready status.
+// Uses UnityEngine.UI (legacy UI) -- same as SplashScreen.cs pattern.
+// No external dependencies. NetworkManager must exist in scene.
+
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace Plaga44.Networking
+{
+    /// <summary>
+    /// Tracks one player entry visible in the lobby list.
+    /// </summary>
+    [Serializable]
+    public struct LobbyPlayerEntry
+    {
+        public int    PlayerId;
+        public string DisplayName;
+        public bool   IsReady;
+        public bool   IsLocal;
+    }
+
+    /// <summary>
+    /// World-space lobby panel. Attach to any GameObject.
+    /// The panel spawns its own Canvas and builds the UI at runtime.
+    ///
+    /// Layout:
+    ///   [PLAGA '44 -- LOBBY]
+    ///   Room ID: [______] [Create] [Join]
+    ///   --------------------------------
+    ///   Players:
+    ///     > P0 (You)  [READY]
+    ///     > P1        [ --- ]
+    ///   --------------------------------
+    ///   [READY UP]          [LEAVE]
+    ///   Status: Waiting for players...
+    /// </summary>
+    public sealed class LobbyUI : MonoBehaviour
+    {
+        // ---- Inspector ----
+        [Header("Placement")]
+        [Tooltip("Distance in front of the player camera when auto-placed.")]
+        public float PlacementDistance = 1.5f;
+
+        [Tooltip("Height offset from camera position.")]
+        public float HeightOffset = -0.1f;
+
+        [Tooltip("World-space canvas scale.")]
+        public float CanvasScale = 0.001f;
+
+        [Tooltip("Canvas width in pixels (UI units).")]
+        public float CanvasWidth = 600f;
+
+        [Tooltip("Canvas height in pixels (UI units).")]
+        public float CanvasHeight = 500f;
+
+        [Header("Appearance")]
+        public Color BackgroundColor  = new Color(0.05f, 0.05f, 0.08f, 0.97f);
+        public Color AccentColor      = new Color(0.8f, 0.15f, 0.1f, 1f);   // red
+        public Color TextColor        = Color.white;
+        public Color ReadyColor       = new Color(0.2f, 0.85f, 0.3f, 1f);
+        public Color NotReadyColor    = new Color(0.5f, 0.5f, 0.5f, 1f);
+
+        [Header("Behaviour")]
+        [Tooltip("Show/hide lobby on Start. Can also toggle at runtime via ShowLobby()/HideLobby().")]
+        public bool ShowOnStart = true;
+
+        // ---- Private: UI refs ----
+        private Canvas        _canvas;
+        private RectTransform _canvasRect;
+        private InputField    _roomIdInput;
+        private Button        _createBtn;
+        private Button        _joinBtn;
+        private Button        _readyBtn;
+        private Button        _leaveBtn;
+        private Text          _statusText;
+        private Transform     _playerListRoot;
+
+        // ---- Private: state ----
+        private readonly List<LobbyPlayerEntry> _players = new List<LobbyPlayerEntry>();
+        private readonly List<GameObject>       _playerRows = new List<GameObject>();
+        private bool   _localReady = false;
+        private string _currentRoomId = "";
+
+        private Font _font;
+
+        // ---- Lifecycle ----
+        private void Start()
+        {
+            _font = Font.CreateDynamicFontFromOSFont("Consolas", 14);
+
+            BuildCanvas();
+            BuildUI();
+            RegisterNetworkEvents();
+
+            if (ShowOnStart)
+                ShowLobby();
+            else
+                HideLobby();
+        }
+
+        private void OnDestroy()
+        {
+            UnregisterNetworkEvents();
+        }
+
+        private void Update()
+        {
+            // If canvas is visible, billboard it toward the camera.
+            if (_canvas != null && _canvas.gameObject.activeSelf)
+                FaceCamera();
+        }
+
+        // ---- Public API ----
+        public void ShowLobby()
+        {
+            if (_canvas != null) _canvas.gameObject.SetActive(true);
+            PlaceInFrontOfCamera();
+        }
+
+        public void HideLobby()
+        {
+            if (_canvas != null) _canvas.gameObject.SetActive(false);
+        }
+
+        public void AddOrUpdatePlayer(LobbyPlayerEntry entry)
+        {
+            int idx = _players.FindIndex(p => p.PlayerId == entry.PlayerId);
+            if (idx >= 0)
+                _players[idx] = entry;
+            else
+                _players.Add(entry);
+
+            RefreshPlayerList();
+        }
+
+        public void RemovePlayer(int playerId)
+        {
+            _players.RemoveAll(p => p.PlayerId == playerId);
+            RefreshPlayerList();
+        }
+
+        public void SetStatus(string message)
+        {
+            if (_statusText != null)
+                _statusText.text = "Status: " + message;
+        }
+
+        // ---- Button handlers ----
+        private void OnCreateClicked()
+        {
+            string roomId = GetRoomId();
+            SetStatus($"Creating room '{roomId}'...");
+            DisableConnectionButtons();
+
+            NetworkManager.Instance.Connect(roomId, success =>
+            {
+                if (success)
+                {
+                    SetStatus($"Room '{roomId}' created. Waiting for players...");
+                    AddLocalPlayer();
+                }
+                else
+                {
+                    SetStatus("Failed to create room.");
+                    EnableConnectionButtons();
+                }
+            });
+        }
+
+        private void OnJoinClicked()
+        {
+            string roomId = GetRoomId();
+            SetStatus($"Joining room '{roomId}'...");
+            DisableConnectionButtons();
+
+            NetworkManager.Instance.Connect(roomId, success =>
+            {
+                if (success)
+                {
+                    SetStatus($"Joined room '{roomId}'.");
+                    AddLocalPlayer();
+                }
+                else
+                {
+                    SetStatus("Failed to join room.");
+                    EnableConnectionButtons();
+                }
+            });
+        }
+
+        private void OnReadyClicked()
+        {
+            _localReady = !_localReady;
+
+            int localId = NetworkManager.Instance != null ? NetworkManager.Instance.LocalPlayerId : 0;
+            int idx = _players.FindIndex(p => p.PlayerId == localId);
+            if (idx >= 0)
+            {
+                var entry = _players[idx];
+                entry.IsReady = _localReady;
+                _players[idx] = entry;
+            }
+
+            RefreshPlayerList();
+            UpdateReadyButton();
+            SetStatus(_localReady ? "Marked as ready." : "Cancelled ready.");
+        }
+
+        private void OnLeaveClicked()
+        {
+            if (NetworkManager.Instance != null && NetworkManager.Instance.IsConnected)
+                NetworkManager.Instance.Disconnect();
+
+            _players.Clear();
+            RefreshPlayerList();
+            _localReady = false;
+            UpdateReadyButton();
+            EnableConnectionButtons();
+            SetStatus("Left room.");
+        }
+
+        // ---- Network event handlers ----
+        private void RegisterNetworkEvents()
+        {
+            if (NetworkManager.Instance == null) return;
+            NetworkManager.Instance.OnConnected      += HandleConnected;
+            NetworkManager.Instance.OnDisconnected   += HandleDisconnected;
+            NetworkManager.Instance.OnPlayerJoined   += HandlePlayerJoined;
+            NetworkManager.Instance.OnPlayerLeft     += HandlePlayerLeft;
+        }
+
+        private void UnregisterNetworkEvents()
+        {
+            if (NetworkManager.Instance == null) return;
+            NetworkManager.Instance.OnConnected      -= HandleConnected;
+            NetworkManager.Instance.OnDisconnected   -= HandleDisconnected;
+            NetworkManager.Instance.OnPlayerJoined   -= HandlePlayerJoined;
+            NetworkManager.Instance.OnPlayerLeft     -= HandlePlayerLeft;
+        }
+
+        private void HandleConnected(int localPlayerId)
+        {
+            SetStatus("Connected.");
+        }
+
+        private void HandleDisconnected()
+        {
+            _players.Clear();
+            RefreshPlayerList();
+            SetStatus("Disconnected.");
+            EnableConnectionButtons();
+        }
+
+        private void HandlePlayerJoined(int playerId)
+        {
+            int localId = NetworkManager.Instance != null ? NetworkManager.Instance.LocalPlayerId : -1;
+            if (playerId == localId) return; // local already added
+
+            var entry = new LobbyPlayerEntry
+            {
+                PlayerId    = playerId,
+                DisplayName = $"Player {playerId}",
+                IsReady     = false,
+                IsLocal     = false
+            };
+            AddOrUpdatePlayer(entry);
+            SetStatus($"Player {playerId} joined.");
+        }
+
+        private void HandlePlayerLeft(int playerId)
+        {
+            RemovePlayer(playerId);
+            SetStatus($"Player {playerId} left.");
+        }
+
+        // ---- Helpers ----
+        private string GetRoomId()
+        {
+            string id = _roomIdInput != null ? _roomIdInput.text.Trim() : "";
+            if (string.IsNullOrEmpty(id))
+                id = NetworkManager.Instance != null ? NetworkManager.Instance.defaultRoomId : "plaga44";
+            _currentRoomId = id;
+            return id;
+        }
+
+        private void AddLocalPlayer()
+        {
+            int localId = NetworkManager.Instance != null ? NetworkManager.Instance.LocalPlayerId : 0;
+            var entry = new LobbyPlayerEntry
+            {
+                PlayerId    = localId,
+                DisplayName = $"Player {localId} (You)",
+                IsReady     = false,
+                IsLocal     = true
+            };
+            AddOrUpdatePlayer(entry);
+        }
+
+        private void DisableConnectionButtons()
+        {
+            if (_createBtn != null) _createBtn.interactable = false;
+            if (_joinBtn   != null) _joinBtn.interactable   = false;
+        }
+
+        private void EnableConnectionButtons()
+        {
+            if (_createBtn != null) _createBtn.interactable = true;
+            if (_joinBtn   != null) _joinBtn.interactable   = true;
+        }
+
+        private void UpdateReadyButton()
+        {
+            if (_readyBtn == null) return;
+            var label = _readyBtn.GetComponentInChildren<Text>();
+            if (label != null)
+                label.text = _localReady ? "CANCEL READY" : "READY UP";
+
+            var btnImage = _readyBtn.GetComponent<Image>();
+            if (btnImage != null)
+                btnImage.color = _localReady ? ReadyColor : AccentColor;
+        }
+
+        private void RefreshPlayerList()
+        {
+            if (_playerListRoot == null) return;
+
+            // Destroy old rows
+            foreach (var row in _playerRows)
+                if (row != null) Destroy(row);
+            _playerRows.Clear();
+
+            float rowH = 30f;
+            float y = 0f;
+
+            foreach (var player in _players)
+            {
+                var rowGO = new GameObject($"PlayerRow_{player.PlayerId}");
+                rowGO.transform.SetParent(_playerListRoot, false);
+
+                var rowRect = rowGO.AddComponent<RectTransform>();
+                rowRect.anchorMin = new Vector2(0f, 1f);
+                rowRect.anchorMax = new Vector2(1f, 1f);
+                rowRect.pivot     = new Vector2(0.5f, 1f);
+                rowRect.sizeDelta = new Vector2(0f, rowH);
+                rowRect.anchoredPosition = new Vector2(0f, -y);
+
+                // Name label
+                var nameGO   = new GameObject("Name");
+                nameGO.transform.SetParent(rowGO.transform, false);
+                var nameTxt  = nameGO.AddComponent<Text>();
+                nameTxt.text = $"  > {player.DisplayName}";
+                nameTxt.font      = _font;
+                nameTxt.fontSize  = 13;
+                nameTxt.color     = player.IsLocal ? AccentColor : TextColor;
+                nameTxt.alignment = TextAnchor.MiddleLeft;
+                nameTxt.horizontalOverflow = HorizontalWrapMode.Overflow;
+                var nameRect = nameGO.GetComponent<RectTransform>();
+                nameRect.anchorMin        = new Vector2(0f, 0f);
+                nameRect.anchorMax        = new Vector2(0.7f, 1f);
+                nameRect.offsetMin        = Vector2.zero;
+                nameRect.offsetMax        = Vector2.zero;
+
+                // Ready label
+                var rdyGO  = new GameObject("Ready");
+                rdyGO.transform.SetParent(rowGO.transform, false);
+                var rdyTxt = rdyGO.AddComponent<Text>();
+                rdyTxt.text      = player.IsReady ? "[READY]" : "[ --- ]";
+                rdyTxt.font      = _font;
+                rdyTxt.fontSize  = 13;
+                rdyTxt.color     = player.IsReady ? ReadyColor : NotReadyColor;
+                rdyTxt.alignment = TextAnchor.MiddleRight;
+                rdyTxt.horizontalOverflow = HorizontalWrapMode.Overflow;
+                var rdyRect = rdyGO.GetComponent<RectTransform>();
+                rdyRect.anchorMin = new Vector2(0.7f, 0f);
+                rdyRect.anchorMax = new Vector2(1f, 1f);
+                rdyRect.offsetMin = Vector2.zero;
+                rdyRect.offsetMax = new Vector2(-8f, 0f);
+
+                _playerRows.Add(rowGO);
+                y += rowH;
+            }
+
+            // Resize list root to fit
+            var listRect = _playerListRoot.GetComponent<RectTransform>();
+            if (listRect != null)
+                listRect.sizeDelta = new Vector2(listRect.sizeDelta.x, Mathf.Max(y, 30f));
+        }
+
+        private void FaceCamera()
+        {
+            var cam = Camera.main;
+            if (cam == null) return;
+            _canvas.transform.LookAt(_canvas.transform.position + cam.transform.forward);
+        }
+
+        private void PlaceInFrontOfCamera()
+        {
+            var cam = Camera.main;
+            if (cam == null || _canvas == null) return;
+
+            Vector3 pos = cam.transform.position
+                + cam.transform.forward * PlacementDistance
+                + Vector3.up * HeightOffset;
+            _canvas.transform.position = pos;
+            FaceCamera();
+        }
+
+        // ---- UI Construction ----
+        private void BuildCanvas()
+        {
+            var go = new GameObject("[LobbyCanvas]");
+            go.transform.SetParent(transform, false);
+
+            _canvas = go.AddComponent<Canvas>();
+            _canvas.renderMode  = RenderMode.WorldSpace;
+            _canvas.sortingOrder = 100;
+
+            go.AddComponent<GraphicRaycaster>();
+
+            _canvasRect = _canvas.GetComponent<RectTransform>();
+            _canvasRect.sizeDelta = new Vector2(CanvasWidth, CanvasHeight);
+            _canvasRect.localScale = Vector3.one * CanvasScale;
+        }
+
+        private void BuildUI()
+        {
+            float pad = 16f;
+            float y   = -pad;  // current vertical cursor from top
+
+            // -- Background panel --
+            MakeImage(_canvas.transform, "Background", BackgroundColor,
+                Vector2.zero, Vector2.one, Vector2.zero, Vector2.zero);
+
+            // -- Title --
+            var title = MakeText(_canvas.transform, "Title",
+                "PLAGA '44 -- LOBBY", 18, AccentColor, TextAnchor.UpperCenter);
+            SetRect(title.transform, new Vector2(0f, 1f), new Vector2(1f, 1f),
+                new Vector2(0f, -48f), new Vector2(0f, 0f));
+
+            y -= 40f;
+
+            // -- Separator --
+            MakeSeparator(_canvas.transform, y);
+            y -= 6f;
+
+            // -- Room ID row --
+            float rowY = y;
+            _roomIdInput = MakeInputField(_canvas.transform, "RoomInput",
+                "Room ID...", 13, rowY, -pad, CanvasWidth * 0.5f - pad * 2f);
+
+            _createBtn = MakeButton(_canvas.transform, "CreateBtn", "CREATE",
+                13, rowY, pad + CanvasWidth * 0.5f, 80f);
+            _createBtn.onClick.AddListener(OnCreateClicked);
+
+            _joinBtn = MakeButton(_canvas.transform, "JoinBtn", "JOIN",
+                13, rowY, pad + CanvasWidth * 0.5f + 90f, 70f);
+            _joinBtn.onClick.AddListener(OnJoinClicked);
+
+            y -= 36f;
+
+            // -- Separator --
+            MakeSeparator(_canvas.transform, y);
+            y -= 10f;
+
+            // -- "Players:" label --
+            var playersLabel = MakeText(_canvas.transform, "PlayersLabel",
+                "Players:", 13, TextColor, TextAnchor.UpperLeft);
+            SetRect(playersLabel.transform,
+                new Vector2(0f, 1f), new Vector2(1f, 1f),
+                new Vector2(0f, y - 20f), new Vector2(0f, y));
+
+            y -= 24f;
+
+            // -- Player list root --
+            var listGO = new GameObject("PlayerList");
+            listGO.transform.SetParent(_canvas.transform, false);
+            _playerListRoot = listGO.transform;
+            var listRect = listGO.AddComponent<RectTransform>();
+            listRect.anchorMin = new Vector2(0f, 1f);
+            listRect.anchorMax = new Vector2(1f, 1f);
+            listRect.pivot     = new Vector2(0.5f, 1f);
+            listRect.offsetMin = new Vector2(pad, 0f);
+            listRect.offsetMax = new Vector2(-pad, 0f);
+            listRect.anchoredPosition = new Vector2(0f, y);
+            listRect.sizeDelta = new Vector2(0f, 120f);
+
+            y -= 130f;
+
+            // -- Separator --
+            MakeSeparator(_canvas.transform, y);
+            y -= 6f;
+
+            // -- Ready + Leave buttons --
+            _readyBtn = MakeButton(_canvas.transform, "ReadyBtn", "READY UP",
+                14, y, pad, 120f);
+            _readyBtn.onClick.AddListener(OnReadyClicked);
+            _readyBtn.GetComponent<Image>().color = AccentColor;
+
+            _leaveBtn = MakeButton(_canvas.transform, "LeaveBtn", "LEAVE",
+                14, y, CanvasWidth - pad - 80f, 80f);
+            _leaveBtn.onClick.AddListener(OnLeaveClicked);
+            _leaveBtn.GetComponent<Image>().color = new Color(0.3f, 0.3f, 0.35f);
+
+            y -= 46f;
+
+            // -- Status text --
+            _statusText = MakeText(_canvas.transform, "StatusText",
+                "Status: Not connected.", 11, NotReadyColor, TextAnchor.LowerLeft);
+            SetRect(_statusText.transform,
+                new Vector2(0f, 0f), new Vector2(1f, 0f),
+                new Vector2(0f, 8f), new Vector2(0f, 28f));
+        }
+
+        // ---- Factory helpers ----
+        private Image MakeImage(Transform parent, string name, Color color,
+            Vector2 anchorMin, Vector2 anchorMax, Vector2 offsetMin, Vector2 offsetMax)
+        {
+            var go   = new GameObject(name);
+            go.transform.SetParent(parent, false);
+            var img  = go.AddComponent<Image>();
+            img.color = color;
+            var rect = go.GetComponent<RectTransform>();
+            rect.anchorMin = anchorMin;
+            rect.anchorMax = anchorMax;
+            rect.offsetMin = offsetMin;
+            rect.offsetMax = offsetMax;
+            return img;
+        }
+
+        private Text MakeText(Transform parent, string name, string content,
+            int fontSize, Color color, TextAnchor alignment)
+        {
+            var go  = new GameObject(name);
+            go.transform.SetParent(parent, false);
+            var txt = go.AddComponent<Text>();
+            txt.text      = content;
+            txt.font      = _font;
+            txt.fontSize  = fontSize;
+            txt.color     = color;
+            txt.alignment = alignment;
+            txt.horizontalOverflow = HorizontalWrapMode.Wrap;
+            txt.verticalOverflow   = VerticalWrapMode.Overflow;
+            return txt;
+        }
+
+        private void MakeSeparator(Transform parent, float anchoredY)
+        {
+            var sep = MakeImage(parent, "Sep",
+                new Color(1f, 1f, 1f, 0.15f),
+                new Vector2(0f, 1f), new Vector2(1f, 1f),
+                new Vector2(8f, 0f), new Vector2(-8f, 0f));
+            var r = sep.GetComponent<RectTransform>();
+            r.anchoredPosition = new Vector2(0f, anchoredY);
+            r.sizeDelta        = new Vector2(0f, 1f);
+        }
+
+        private InputField MakeInputField(Transform parent, string name,
+            string placeholder, int fontSize, float anchoredY, float x, float width)
+        {
+            var go   = new GameObject(name);
+            go.transform.SetParent(parent, false);
+            var img  = go.AddComponent<Image>();
+            img.color = new Color(0.15f, 0.15f, 0.18f, 1f);
+            var rect = go.GetComponent<RectTransform>();
+            rect.anchorMin        = new Vector2(0f, 1f);
+            rect.anchorMax        = new Vector2(0f, 1f);
+            rect.pivot            = new Vector2(0f, 1f);
+            rect.anchoredPosition = new Vector2(x, anchoredY);
+            rect.sizeDelta        = new Vector2(width, 28f);
+
+            // Placeholder text
+            var phGO  = new GameObject("Placeholder");
+            phGO.transform.SetParent(go.transform, false);
+            var phTxt = phGO.AddComponent<Text>();
+            phTxt.text     = placeholder;
+            phTxt.font     = _font;
+            phTxt.fontSize = fontSize;
+            phTxt.color    = new Color(0.5f, 0.5f, 0.5f, 0.7f);
+            phTxt.alignment = TextAnchor.MiddleLeft;
+            FillRect(phTxt.transform, 4f);
+
+            // Input text
+            var txtGO  = new GameObject("Text");
+            txtGO.transform.SetParent(go.transform, false);
+            var inTxt  = txtGO.AddComponent<Text>();
+            inTxt.font     = _font;
+            inTxt.fontSize = fontSize;
+            inTxt.color    = TextColor;
+            inTxt.alignment = TextAnchor.MiddleLeft;
+            FillRect(inTxt.transform, 4f);
+
+            var field = go.AddComponent<InputField>();
+            field.textComponent   = inTxt;
+            field.placeholder     = phTxt;
+            field.characterLimit  = 32;
+
+            return field;
+        }
+
+        private Button MakeButton(Transform parent, string name, string label,
+            int fontSize, float anchoredY, float x, float width)
+        {
+            var go   = new GameObject(name);
+            go.transform.SetParent(parent, false);
+            var img  = go.AddComponent<Image>();
+            img.color = AccentColor;
+            var rect = go.GetComponent<RectTransform>();
+            rect.anchorMin        = new Vector2(0f, 1f);
+            rect.anchorMax        = new Vector2(0f, 1f);
+            rect.pivot            = new Vector2(0f, 1f);
+            rect.anchoredPosition = new Vector2(x, anchoredY);
+            rect.sizeDelta        = new Vector2(width, 30f);
+
+            var lblGO = new GameObject("Label");
+            lblGO.transform.SetParent(go.transform, false);
+            var txt   = lblGO.AddComponent<Text>();
+            txt.text      = label;
+            txt.font      = _font;
+            txt.fontSize  = fontSize;
+            txt.color     = Color.white;
+            txt.alignment = TextAnchor.MiddleCenter;
+            FillRect(txt.transform, 0f);
+
+            var btn = go.AddComponent<Button>();
+            var colors = btn.colors;
+            colors.normalColor      = Color.white;
+            colors.highlightedColor = new Color(1.2f, 1.2f, 1.2f);
+            colors.pressedColor     = new Color(0.7f, 0.7f, 0.7f);
+            btn.colors = colors;
+
+            return btn;
+        }
+
+        private void SetRect(Transform t, Vector2 anchorMin, Vector2 anchorMax,
+            Vector2 offsetMin, Vector2 offsetMax)
+        {
+            var r = t.GetComponent<RectTransform>();
+            if (r == null) return;
+            r.anchorMin = anchorMin;
+            r.anchorMax = anchorMax;
+            r.offsetMin = offsetMin;
+            r.offsetMax = offsetMax;
+        }
+
+        private void FillRect(Transform t, float padding)
+        {
+            var r = t.GetComponent<RectTransform>();
+            if (r == null) return;
+            r.anchorMin = Vector2.zero;
+            r.anchorMax = Vector2.one;
+            r.offsetMin = new Vector2(padding, padding);
+            r.offsetMax = new Vector2(-padding, -padding);
+        }
+    }
+}

--- a/Assets/Scripts/Networking/NetworkInterpolator.cs
+++ b/Assets/Scripts/Networking/NetworkInterpolator.cs
@@ -1,0 +1,208 @@
+// NetworkInterpolator.cs
+// CYBERNOMAD -- PLAGA '44
+// Smooths out remote player movement by maintaining a small snapshot buffer
+// and rendering at (now - interpolationDelay). Lerp between two bracketing
+// snapshots each frame so the avatar looks smooth even with jitter / packet loss.
+
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace Plaga44.Networking
+{
+    /// <summary>
+    /// Attach to a remote player GameObject.
+    /// Receives PlayerPoseSnapshots from NetworkPlayer and applies interpolated
+    /// transforms to the avatar bones each Update.
+    /// </summary>
+    public sealed class NetworkInterpolator : MonoBehaviour
+    {
+        // ---- Inspector ----
+        [Header("Interpolation")]
+        [Tooltip("How many milliseconds behind real-time to render. Increase to hide more jitter.")]
+        [Range(20f, 300f)]
+        public float InterpolationDelayMs = 50f;
+
+        [Tooltip("Maximum snapshots to keep in buffer. Old snapshots beyond this are dropped.")]
+        [Range(8, 64)]
+        public int BufferSize = 32;
+
+        [Header("Avatar bones")]
+        [Tooltip("Receives interpolated head transform.")]
+        public Transform HeadBone;
+
+        [Tooltip("Receives interpolated left hand transform.")]
+        public Transform LeftHandBone;
+
+        [Tooltip("Receives interpolated right hand transform.")]
+        public Transform RightHandBone;
+
+        [Header("Debug")]
+        public bool ShowDebugGizmos = false;
+
+        // ---- Private ----
+        // Buffer is kept sorted ascending by Timestamp.
+        private readonly List<PlayerPoseSnapshot> _buffer = new List<PlayerPoseSnapshot>(64);
+
+        private double _delaySeconds;
+
+        // ---- Lifecycle ----
+        private void OnEnable()
+        {
+            _buffer.Clear();
+        }
+
+        private void Update()
+        {
+            _delaySeconds = InterpolationDelayMs / 1000.0;
+            double renderTime = Time.timeAsDouble - _delaySeconds;
+            ApplyInterpolated(renderTime);
+        }
+
+        // ---- Public API ----
+        /// <summary>
+        /// Push a newly received snapshot into the buffer.
+        /// Called by NetworkPlayer when a packet arrives.
+        /// </summary>
+        public void PushSnapshot(PlayerPoseSnapshot snap)
+        {
+            // Insert in sorted order (ascending Timestamp).
+            // In practice packets usually arrive in order, so insertion at the end is common.
+            int insertAt = _buffer.Count;
+            for (int i = _buffer.Count - 1; i >= 0; i--)
+            {
+                if (_buffer[i].Timestamp <= snap.Timestamp)
+                {
+                    insertAt = i + 1;
+                    break;
+                }
+                insertAt = i;
+            }
+            _buffer.Insert(insertAt, snap);
+
+            // Trim old snapshots that are way behind the render window.
+            // Keep at least 2 so we can always interpolate.
+            double renderTime = Time.timeAsDouble - _delaySeconds;
+            while (_buffer.Count > 2 && _buffer[0].Timestamp < renderTime - 1.0)
+                _buffer.RemoveAt(0);
+
+            // Hard cap on buffer size
+            while (_buffer.Count > BufferSize)
+                _buffer.RemoveAt(0);
+        }
+
+        /// <summary>
+        /// Clear the snapshot buffer (e.g. on teleport / respawn).
+        /// </summary>
+        public void ClearBuffer()
+        {
+            _buffer.Clear();
+        }
+
+        // ---- Interpolation logic ----
+        private void ApplyInterpolated(double renderTime)
+        {
+            if (_buffer.Count == 0) return;
+
+            // Find the two snapshots that bracket renderTime.
+            // bufferA.Timestamp <= renderTime < bufferB.Timestamp
+            int idxB = -1;
+            for (int i = 0; i < _buffer.Count; i++)
+            {
+                if (_buffer[i].Timestamp >= renderTime)
+                {
+                    idxB = i;
+                    break;
+                }
+            }
+
+            PlayerPoseSnapshot snapA, snapB;
+
+            if (idxB < 0)
+            {
+                // renderTime is ahead of all snapshots -- use the latest snapshot as-is.
+                snapB = _buffer[_buffer.Count - 1];
+                ApplyExact(ref snapB);
+                return;
+            }
+
+            if (idxB == 0)
+            {
+                // renderTime is before any snapshot -- use the earliest.
+                snapA = _buffer[0];
+                ApplyExact(ref snapA);
+                return;
+            }
+
+            snapA = _buffer[idxB - 1];
+            snapB = _buffer[idxB];
+
+            double span = snapB.Timestamp - snapA.Timestamp;
+            float t = (span > 0.0001) ? (float)((renderTime - snapA.Timestamp) / span) : 1f;
+            t = Mathf.Clamp01(t);
+
+            ApplyLerp(ref snapA, ref snapB, t);
+        }
+
+        private void ApplyExact(ref PlayerPoseSnapshot snap)
+        {
+            if (HeadBone      != null) { HeadBone.position      = snap.HeadPos;      HeadBone.rotation      = snap.HeadRot; }
+            if (LeftHandBone  != null) { LeftHandBone.position  = snap.LeftHandPos;  LeftHandBone.rotation  = snap.LeftHandRot; }
+            if (RightHandBone != null) { RightHandBone.position = snap.RightHandPos; RightHandBone.rotation = snap.RightHandRot; }
+        }
+
+        private void ApplyLerp(ref PlayerPoseSnapshot a, ref PlayerPoseSnapshot b, float t)
+        {
+            if (HeadBone != null)
+            {
+                HeadBone.position = Vector3.Lerp(a.HeadPos, b.HeadPos, t);
+                HeadBone.rotation = Quaternion.Slerp(a.HeadRot, b.HeadRot, t);
+            }
+            if (LeftHandBone != null)
+            {
+                LeftHandBone.position = Vector3.Lerp(a.LeftHandPos, b.LeftHandPos, t);
+                LeftHandBone.rotation = Quaternion.Slerp(a.LeftHandRot, b.LeftHandRot, t);
+            }
+            if (RightHandBone != null)
+            {
+                RightHandBone.position = Vector3.Lerp(a.RightHandPos, b.RightHandPos, t);
+                RightHandBone.rotation = Quaternion.Slerp(a.RightHandRot, b.RightHandRot, t);
+            }
+        }
+
+        // ---- Gizmos ----
+#if UNITY_EDITOR
+        private void OnDrawGizmos()
+        {
+            if (!ShowDebugGizmos) return;
+
+            // Draw interpolation buffer snapshots as small spheres for head position.
+            double renderTime = Time.timeAsDouble - InterpolationDelayMs / 1000.0;
+
+            Gizmos.color = Color.grey;
+            foreach (var snap in _buffer)
+                Gizmos.DrawWireSphere(snap.HeadPos, 0.04f);
+
+            // Show render cursor
+            if (_buffer.Count >= 2)
+            {
+                Gizmos.color = Color.cyan;
+                // Approximate render head position
+                int idxB = -1;
+                for (int i = 0; i < _buffer.Count; i++)
+                {
+                    if (_buffer[i].Timestamp >= renderTime) { idxB = i; break; }
+                }
+                if (idxB > 0)
+                {
+                    var a = _buffer[idxB - 1];
+                    var b = _buffer[idxB];
+                    double span = b.Timestamp - a.Timestamp;
+                    float t = (span > 0) ? (float)((renderTime - a.Timestamp) / span) : 1f;
+                    Vector3 pos = Vector3.Lerp(a.HeadPos, b.HeadPos, Mathf.Clamp01(t));
+                    Gizmos.DrawSphere(pos, 0.06f);
+                }
+            }
+        }
+#endif
+    }
+}

--- a/Assets/Scripts/Networking/NetworkManager.cs
+++ b/Assets/Scripts/Networking/NetworkManager.cs
@@ -1,0 +1,256 @@
+// NetworkManager.cs
+// CYBERNOMAD -- PLAGA '44
+// Singleton abstraction over network transport (Photon/Netcode-ready).
+// Current implementation: local loopback placeholder.
+// To swap transport: implement INetworkTransport and assign via SetTransport().
+
+using System;
+using UnityEngine;
+
+namespace Plaga44.Networking
+{
+    /// <summary>
+    /// Minimal transport interface -- implement this to plug in Photon, Unity Netcode, etc.
+    /// </summary>
+    public interface INetworkTransport
+    {
+        bool IsConnected { get; }
+        bool IsHost { get; }
+        void Connect(string roomId, Action<bool> onResult);
+        void Disconnect();
+        void SendReliable(byte[] data, int targetPlayerId);
+        void SendUnreliable(byte[] data, int targetPlayerId);
+        event Action<int, byte[]> OnDataReceived;   // (senderId, data)
+        event Action<int> OnPlayerJoined;           // playerId
+        event Action<int> OnPlayerLeft;             // playerId
+    }
+
+    /// <summary>
+    /// Local loopback transport -- reflects all sends back to itself.
+    /// Used for solo testing without a real server.
+    /// </summary>
+    internal sealed class LocalLoopbackTransport : INetworkTransport
+    {
+        private bool _connected;
+
+        public bool IsConnected => _connected;
+        public bool IsHost => _connected;  // loopback is always host
+
+        public event Action<int, byte[]> OnDataReceived;
+        public event Action<int> OnPlayerJoined;
+        public event Action<int> OnPlayerLeft;
+
+        public void Connect(string roomId, Action<bool> onResult)
+        {
+            _connected = true;
+            Debug.Log($"[NetworkManager] LocalLoopback: connected to room '{roomId}'");
+            onResult?.Invoke(true);
+            OnPlayerJoined?.Invoke(0);  // local player id = 0
+        }
+
+        public void Disconnect()
+        {
+            if (!_connected) return;
+            _connected = false;
+            OnPlayerLeft?.Invoke(0);
+            Debug.Log("[NetworkManager] LocalLoopback: disconnected");
+        }
+
+        public void SendReliable(byte[] data, int targetPlayerId)
+        {
+            // Loopback: reflect data back to caller immediately
+            OnDataReceived?.Invoke(0, data);
+        }
+
+        public void SendUnreliable(byte[] data, int targetPlayerId)
+        {
+            OnDataReceived?.Invoke(0, data);
+        }
+    }
+
+    /// <summary>
+    /// MonoBehaviour singleton. Manages network lifecycle.
+    /// Place on a persistent GameObject in the scene.
+    /// </summary>
+    public sealed class NetworkManager : MonoBehaviour
+    {
+        // ---- Singleton ----
+        private static NetworkManager _instance;
+
+        public static NetworkManager Instance
+        {
+            get
+            {
+                if (_instance == null)
+                {
+                    var go = new GameObject("[NetworkManager]");
+                    DontDestroyOnLoad(go);
+                    _instance = go.AddComponent<NetworkManager>();
+                }
+                return _instance;
+            }
+        }
+
+        // ---- Inspector ----
+        [Header("Connection")]
+        [Tooltip("Room / lobby ID used when no explicit ID is provided to Connect().")]
+        public string defaultRoomId = "plaga44-default";
+
+        [Tooltip("Maximum players in a room.")]
+        [Range(2, 8)]
+        public int maxPlayers = 4;
+
+        // ---- Public API ----
+        public bool IsConnected => _transport != null && _transport.IsConnected;
+        public bool IsHost     => _transport != null && _transport.IsHost;
+        public int  LocalPlayerId { get; private set; } = -1;
+
+        /// <summary>Fired after successful connect. Arg: local player id.</summary>
+        public event Action<int> OnConnected;
+
+        /// <summary>Fired after disconnect.</summary>
+        public event Action OnDisconnected;
+
+        /// <summary>Fired when remote player joins. Arg: their player id.</summary>
+        public event Action<int> OnPlayerJoined;
+
+        /// <summary>Fired when remote player leaves. Arg: their player id.</summary>
+        public event Action<int> OnPlayerLeft;
+
+        /// <summary>Fired when raw data arrives. Args: senderId, data.</summary>
+        public event Action<int, byte[]> OnDataReceived;
+
+        // ---- Private ----
+        private INetworkTransport _transport;
+
+        // ---- Lifecycle ----
+        private void Awake()
+        {
+            if (_instance != null && _instance != this)
+            {
+                Destroy(gameObject);
+                return;
+            }
+            _instance = this;
+            DontDestroyOnLoad(gameObject);
+
+            // Default: loopback
+            SetTransport(new LocalLoopbackTransport());
+        }
+
+        private void OnDestroy()
+        {
+            if (_instance == this) _instance = null;
+            DetachTransportEvents();
+        }
+
+        // ---- Transport injection ----
+        /// <summary>
+        /// Swap transport at runtime (before connect).
+        /// Example: SetTransport(new PhotonTransport());
+        /// </summary>
+        public void SetTransport(INetworkTransport transport)
+        {
+            DetachTransportEvents();
+            _transport = transport;
+            AttachTransportEvents();
+            Debug.Log($"[NetworkManager] Transport set: {transport?.GetType().Name}");
+        }
+
+        // ---- Public methods ----
+        /// <summary>Connect using the default room ID.</summary>
+        public void Connect(Action<bool> onResult = null)
+        {
+            Connect(defaultRoomId, onResult);
+        }
+
+        /// <summary>Connect to a specific room.</summary>
+        public void Connect(string roomId, Action<bool> onResult = null)
+        {
+            if (_transport == null)
+            {
+                Debug.LogError("[NetworkManager] No transport set.");
+                onResult?.Invoke(false);
+                return;
+            }
+
+            if (IsConnected)
+            {
+                Debug.LogWarning("[NetworkManager] Already connected.");
+                onResult?.Invoke(true);
+                return;
+            }
+
+            Debug.Log($"[NetworkManager] Connecting to room '{roomId}'...");
+            _transport.Connect(roomId, success =>
+            {
+                if (success)
+                {
+                    LocalPlayerId = 0;  // transport should assign real id; loopback = 0
+                    OnConnected?.Invoke(LocalPlayerId);
+                }
+                onResult?.Invoke(success);
+            });
+        }
+
+        public void Disconnect()
+        {
+            if (!IsConnected)
+            {
+                Debug.LogWarning("[NetworkManager] Not connected.");
+                return;
+            }
+            _transport.Disconnect();
+        }
+
+        /// <summary>Send reliable (ordered) data to target player. -1 = broadcast.</summary>
+        public void SendReliable(byte[] data, int targetPlayerId = -1)
+        {
+            if (!IsConnected) return;
+            _transport.SendReliable(data, targetPlayerId);
+        }
+
+        /// <summary>Send unreliable (unordered, low-latency) data. -1 = broadcast.</summary>
+        public void SendUnreliable(byte[] data, int targetPlayerId = -1)
+        {
+            if (!IsConnected) return;
+            _transport.SendUnreliable(data, targetPlayerId);
+        }
+
+        // ---- Event wiring ----
+        private void AttachTransportEvents()
+        {
+            if (_transport == null) return;
+            _transport.OnDataReceived  += HandleDataReceived;
+            _transport.OnPlayerJoined  += HandlePlayerJoined;
+            _transport.OnPlayerLeft    += HandlePlayerLeft;
+        }
+
+        private void DetachTransportEvents()
+        {
+            if (_transport == null) return;
+            _transport.OnDataReceived  -= HandleDataReceived;
+            _transport.OnPlayerJoined  -= HandlePlayerJoined;
+            _transport.OnPlayerLeft    -= HandlePlayerLeft;
+        }
+
+        private void HandleDataReceived(int senderId, byte[] data)
+        {
+            OnDataReceived?.Invoke(senderId, data);
+        }
+
+        private void HandlePlayerJoined(int playerId)
+        {
+            Debug.Log($"[NetworkManager] Player joined: {playerId}");
+            OnPlayerJoined?.Invoke(playerId);
+        }
+
+        private void HandlePlayerLeft(int playerId)
+        {
+            Debug.Log($"[NetworkManager] Player left: {playerId}");
+            OnPlayerLeft?.Invoke(playerId);
+            if (playerId == LocalPlayerId)
+                OnDisconnected?.Invoke();
+        }
+    }
+}

--- a/Assets/Scripts/Networking/NetworkPlayer.cs
+++ b/Assets/Scripts/Networking/NetworkPlayer.cs
@@ -1,0 +1,312 @@
+// NetworkPlayer.cs
+// CYBERNOMAD -- PLAGA '44
+// Represents one player in the network session.
+// Local player: serializes head + hand transforms into byte[] and sends each FixedUpdate.
+// Remote player: receives byte[], deserializes, feeds into NetworkInterpolator.
+
+using System;
+using UnityEngine;
+
+namespace Plaga44.Networking
+{
+    /// <summary>
+    /// Snapshot of a player's tracked body poses at a given timestamp.
+    /// </summary>
+    [Serializable]
+    public struct PlayerPoseSnapshot
+    {
+        public double Timestamp;        // Time.timeAsDouble when captured
+
+        public Vector3    HeadPos;
+        public Quaternion HeadRot;
+
+        public Vector3    LeftHandPos;
+        public Quaternion LeftHandRot;
+
+        public Vector3    RightHandPos;
+        public Quaternion RightHandRot;
+
+        // Packet ID -- wraps around at 255. Used to detect out-of-order packets.
+        public byte PacketId;
+
+        // ---- Serialization ----
+
+        // Binary layout (bytes):
+        //  1   PacketId
+        //  8   Timestamp (double)
+        //  12  HeadPos        (3 x float)
+        //  16  HeadRot        (4 x float)
+        //  12  LeftHandPos
+        //  16  LeftHandRot
+        //  12  RightHandPos
+        //  16  RightHandRot
+        // Total: 93 bytes
+
+        public const int PacketSize = 1 + 8 + (12 + 16) * 3;  // = 93
+
+        public byte[] Serialize()
+        {
+            byte[] buf = new byte[PacketSize];
+            int offset = 0;
+
+            buf[offset++] = PacketId;
+
+            WriteDouble(buf, ref offset, Timestamp);
+
+            WriteVector3(buf, ref offset, HeadPos);
+            WriteQuaternion(buf, ref offset, HeadRot);
+
+            WriteVector3(buf, ref offset, LeftHandPos);
+            WriteQuaternion(buf, ref offset, LeftHandRot);
+
+            WriteVector3(buf, ref offset, RightHandPos);
+            WriteQuaternion(buf, ref offset, RightHandRot);
+
+            return buf;
+        }
+
+        public static bool TryDeserialize(byte[] buf, out PlayerPoseSnapshot snap)
+        {
+            snap = default;
+            if (buf == null || buf.Length < PacketSize) return false;
+
+            int offset = 0;
+
+            snap.PacketId = buf[offset++];
+            snap.Timestamp = ReadDouble(buf, ref offset);
+
+            snap.HeadPos      = ReadVector3(buf, ref offset);
+            snap.HeadRot      = ReadQuaternion(buf, ref offset);
+
+            snap.LeftHandPos  = ReadVector3(buf, ref offset);
+            snap.LeftHandRot  = ReadQuaternion(buf, ref offset);
+
+            snap.RightHandPos = ReadVector3(buf, ref offset);
+            snap.RightHandRot = ReadQuaternion(buf, ref offset);
+
+            return true;
+        }
+
+        // ---- Low-level helpers ----
+        private static void WriteFloat(byte[] buf, ref int offset, float v)
+        {
+            byte[] bytes = BitConverter.GetBytes(v);
+            Buffer.BlockCopy(bytes, 0, buf, offset, 4);
+            offset += 4;
+        }
+
+        private static float ReadFloat(byte[] buf, ref int offset)
+        {
+            float v = BitConverter.ToSingle(buf, offset);
+            offset += 4;
+            return v;
+        }
+
+        private static void WriteDouble(byte[] buf, ref int offset, double v)
+        {
+            byte[] bytes = BitConverter.GetBytes(v);
+            Buffer.BlockCopy(bytes, 0, buf, offset, 8);
+            offset += 8;
+        }
+
+        private static double ReadDouble(byte[] buf, ref int offset)
+        {
+            double v = BitConverter.ToDouble(buf, offset);
+            offset += 8;
+            return v;
+        }
+
+        private static void WriteVector3(byte[] buf, ref int offset, Vector3 v)
+        {
+            WriteFloat(buf, ref offset, v.x);
+            WriteFloat(buf, ref offset, v.y);
+            WriteFloat(buf, ref offset, v.z);
+        }
+
+        private static Vector3 ReadVector3(byte[] buf, ref int offset)
+        {
+            float x = ReadFloat(buf, ref offset);
+            float y = ReadFloat(buf, ref offset);
+            float z = ReadFloat(buf, ref offset);
+            return new Vector3(x, y, z);
+        }
+
+        private static void WriteQuaternion(byte[] buf, ref int offset, Quaternion q)
+        {
+            WriteFloat(buf, ref offset, q.x);
+            WriteFloat(buf, ref offset, q.y);
+            WriteFloat(buf, ref offset, q.z);
+            WriteFloat(buf, ref offset, q.w);
+        }
+
+        private static Quaternion ReadQuaternion(byte[] buf, ref int offset)
+        {
+            float x = ReadFloat(buf, ref offset);
+            float y = ReadFloat(buf, ref offset);
+            float z = ReadFloat(buf, ref offset);
+            float w = ReadFloat(buf, ref offset);
+            return new Quaternion(x, y, z, w);
+        }
+    }
+
+    /// <summary>
+    /// Represents a networked player. One instance per player in the session.
+    ///
+    /// Local player (IsLocal == true):
+    ///   - Reads transforms from OVRCameraRig anchors each FixedUpdate
+    ///   - Serializes into PlayerPoseSnapshot and sends via NetworkManager
+    ///
+    /// Remote player (IsLocal == false):
+    ///   - Receives snapshots from NetworkManager
+    ///   - Pushes them into NetworkInterpolator for smooth playback
+    /// </summary>
+    public sealed class NetworkPlayer : MonoBehaviour
+    {
+        // ---- Inspector ----
+        [Header("Identity")]
+        public int PlayerId = -1;
+
+        [Tooltip("True = this is the local player (send mode). False = remote (receive mode).")]
+        public bool IsLocal = false;
+
+        [Header("Send rate")]
+        [Tooltip("How many pose packets to send per second.")]
+        [Range(10, 90)]
+        public int SendRateHz = 30;
+
+        [Header("Transform references (local player)")]
+        [Tooltip("CenterEyeAnchor transform. Auto-detected from OVRCameraRig if null.")]
+        public Transform HeadAnchor;
+
+        [Tooltip("LeftHandAnchor transform. Auto-detected from OVRCameraRig if null.")]
+        public Transform LeftHandAnchor;
+
+        [Tooltip("RightHandAnchor transform. Auto-detected from OVRCameraRig if null.")]
+        public Transform RightHandAnchor;
+
+        [Header("Avatar bones (remote player -- apply received poses here)")]
+        public Transform RemoteHeadBone;
+        public Transform RemoteLeftHandBone;
+        public Transform RemoteRightHandBone;
+
+        // ---- Events ----
+        /// <summary>Fired when a new snapshot is received (remote player only).</summary>
+        public event Action<PlayerPoseSnapshot> OnSnapshotReceived;
+
+        // ---- Private ----
+        private NetworkInterpolator _interpolator;
+        private float _sendTimer;
+        private float _sendInterval;
+        private byte  _packetId;
+
+        // ---- Lifecycle ----
+        private void Awake()
+        {
+            _interpolator = GetComponent<NetworkInterpolator>();
+            if (_interpolator == null && !IsLocal)
+                _interpolator = gameObject.AddComponent<NetworkInterpolator>();
+        }
+
+        private void Start()
+        {
+            _sendInterval = 1f / Mathf.Max(1, SendRateHz);
+
+            if (IsLocal)
+                AutoDetectAnchors();
+
+            if (!IsLocal && NetworkManager.Instance != null)
+                NetworkManager.Instance.OnDataReceived += HandleRawData;
+        }
+
+        private void OnDestroy()
+        {
+            if (!IsLocal && NetworkManager.Instance != null)
+                NetworkManager.Instance.OnDataReceived -= HandleRawData;
+        }
+
+        private void FixedUpdate()
+        {
+            if (!IsLocal) return;
+            if (NetworkManager.Instance == null || !NetworkManager.Instance.IsConnected) return;
+
+            _sendTimer += Time.fixedDeltaTime;
+            if (_sendTimer < _sendInterval) return;
+            _sendTimer -= _sendInterval;
+
+            SendSnapshot();
+        }
+
+        // ---- Local: capture + send ----
+        private void SendSnapshot()
+        {
+            var snap = CaptureLocalPose();
+            byte[] data = snap.Serialize();
+            NetworkManager.Instance.SendUnreliable(data);
+        }
+
+        private PlayerPoseSnapshot CaptureLocalPose()
+        {
+            unchecked { _packetId++; }
+
+            return new PlayerPoseSnapshot
+            {
+                PacketId       = _packetId,
+                Timestamp      = Time.timeAsDouble,
+
+                HeadPos        = HeadAnchor      != null ? HeadAnchor.position      : Vector3.zero,
+                HeadRot        = HeadAnchor      != null ? HeadAnchor.rotation      : Quaternion.identity,
+
+                LeftHandPos    = LeftHandAnchor  != null ? LeftHandAnchor.position  : Vector3.zero,
+                LeftHandRot    = LeftHandAnchor  != null ? LeftHandAnchor.rotation  : Quaternion.identity,
+
+                RightHandPos   = RightHandAnchor != null ? RightHandAnchor.position : Vector3.zero,
+                RightHandRot   = RightHandAnchor != null ? RightHandAnchor.rotation : Quaternion.identity,
+            };
+        }
+
+        // ---- Remote: receive + push to interpolator ----
+        private void HandleRawData(int senderId, byte[] data)
+        {
+            // Only process packets that belong to this player's sender id
+            if (senderId != PlayerId) return;
+            if (data == null || data.Length < PlayerPoseSnapshot.PacketSize) return;
+
+            if (!PlayerPoseSnapshot.TryDeserialize(data, out var snap)) return;
+
+            OnSnapshotReceived?.Invoke(snap);
+
+            if (_interpolator != null)
+                _interpolator.PushSnapshot(snap);
+        }
+
+        // ---- Helpers ----
+        private void AutoDetectAnchors()
+        {
+#if HAS_META_XR
+            var rig = FindFirstObjectByType<OVRCameraRig>();
+            if (rig != null)
+            {
+                if (HeadAnchor      == null) HeadAnchor      = rig.centerEyeAnchor;
+                if (LeftHandAnchor  == null) LeftHandAnchor  = rig.leftHandAnchor;
+                if (RightHandAnchor == null) RightHandAnchor = rig.rightHandAnchor;
+                return;
+            }
+#endif
+            // Fallback: use main camera as head
+            if (HeadAnchor == null && Camera.main != null)
+                HeadAnchor = Camera.main.transform;
+        }
+
+        // ---- Public API ----
+        /// <summary>
+        /// Called by external systems (e.g. LobbyUI) to apply a received snapshot
+        /// directly to the avatar bones without using the interpolator.
+        /// </summary>
+        public void ApplySnapshot(PlayerPoseSnapshot snap)
+        {
+            if (RemoteHeadBone      != null) { RemoteHeadBone.position      = snap.HeadPos;      RemoteHeadBone.rotation      = snap.HeadRot; }
+            if (RemoteLeftHandBone  != null) { RemoteLeftHandBone.position  = snap.LeftHandPos;  RemoteLeftHandBone.rotation  = snap.LeftHandRot; }
+            if (RemoteRightHandBone != null) { RemoteRightHandBone.position = snap.RightHandPos; RemoteRightHandBone.rotation = snap.RightHandRot; }
+        }
+    }
+}

--- a/Assets/Scripts/Networking/VoiceChat.cs
+++ b/Assets/Scripts/Networking/VoiceChat.cs
@@ -1,0 +1,252 @@
+// VoiceChat.cs
+// CYBERNOMAD -- PLAGA '44
+// Voice chat placeholder. Stubbed API ready for Photon Voice / Vivox integration.
+// Optionally hooks into OVRLipSync (Meta XR) if the package is present.
+// Compile-time guard: HAS_META_XR  -- OVR types available
+//                     HAS_PHOTON_VOICE -- Photon Voice available (not yet)
+
+using UnityEngine;
+
+namespace Plaga44.Networking
+{
+    /// <summary>
+    /// Voice mode: push-to-talk requires holding a button; always-on streams continuously.
+    /// </summary>
+    public enum VoiceChatMode
+    {
+        AlwaysOn,
+        PushToTalk
+    }
+
+    /// <summary>
+    /// Voice chat placeholder MonoBehaviour.
+    /// Attach to the local player GameObject.
+    ///
+    /// Current state: API stubs only. No audio data is actually transmitted.
+    /// Integration points are marked with TODO comments.
+    ///
+    /// OVRLipSync integration:
+    ///   - If HAS_META_XR is defined and OVRLipSyncContext is found on the avatar,
+    ///     captured mic audio is fed into it each frame to drive lip animation.
+    /// </summary>
+    public sealed class VoiceChat : MonoBehaviour
+    {
+        // ---- Inspector ----
+        [Header("Mode")]
+        public VoiceChatMode Mode = VoiceChatMode.AlwaysOn;
+
+        [Tooltip("OVR button used for push-to-talk (right primary = A button).")]
+        public OVRInput.Button PushToTalkButton = OVRInput.Button.One;
+
+        [Header("Audio")]
+        [Tooltip("Microphone device name. Leave empty to use default device.")]
+        public string MicDeviceName = "";
+
+        [Tooltip("Sample rate for captured audio.")]
+        public int SampleRate = 22050;
+
+        [Tooltip("Capture buffer length in seconds.")]
+        [Range(0.1f, 2f)]
+        public float BufferLengthSeconds = 0.5f;
+
+        [Header("Playback")]
+        [Tooltip("AudioSource used to play back received voice from this player.")]
+        public AudioSource PlaybackSource;
+
+        [Tooltip("Spatial blend for voice playback (0 = 2D, 1 = 3D).")]
+        [Range(0f, 1f)]
+        public float SpatialBlend = 1f;
+
+        [Header("OVRLipSync")]
+        [Tooltip("Enable feeding mic audio into OVRLipSync on the local avatar.")]
+        public bool EnableLipSync = true;
+
+        [Tooltip("LipSync context on this player's avatar mesh. Auto-detected if null.")]
+        public Component LipSyncContext;  // typed as Component to avoid hard dependency
+
+        // ---- Public state ----
+        public bool IsMuted      { get; private set; } = false;
+        public bool IsTransmitting { get; private set; } = false;
+        public bool IsCaptureRunning { get; private set; } = false;
+
+        // ---- Private ----
+        private AudioClip _micClip;
+        private int       _lastMicPosition;
+        private float[]   _sampleBuffer;
+
+        // ---- Lifecycle ----
+        private void Start()
+        {
+            if (PlaybackSource == null)
+            {
+                PlaybackSource = gameObject.AddComponent<AudioSource>();
+                PlaybackSource.spatialBlend = SpatialBlend;
+                PlaybackSource.loop = false;
+                PlaybackSource.playOnAwake = false;
+            }
+
+            AutoDetectLipSync();
+            StartCapture();
+        }
+
+        private void OnDestroy()
+        {
+            StopCapture();
+        }
+
+        private void Update()
+        {
+            if (!IsCaptureRunning) return;
+
+            bool shouldTransmit = ShouldTransmit();
+            IsTransmitting = shouldTransmit;
+
+            if (shouldTransmit)
+                ProcessMicInput();
+        }
+
+        // ---- Public API ----
+        /// <summary>Start capturing microphone input.</summary>
+        public void StartCapture()
+        {
+            if (IsCaptureRunning) return;
+
+            string device = string.IsNullOrEmpty(MicDeviceName) ? null : MicDeviceName;
+
+            // TODO: replace with actual microphone capture when transport is implemented
+            // _micClip = Microphone.Start(device, true, Mathf.CeilToInt(BufferLengthSeconds), SampleRate);
+
+            int bufferSamples = Mathf.CeilToInt(SampleRate * BufferLengthSeconds);
+            _sampleBuffer = new float[bufferSamples];
+            _lastMicPosition = 0;
+            IsCaptureRunning = true;
+
+            Debug.Log($"[VoiceChat] Capture started. Device: '{device ?? "default"}' Rate: {SampleRate}Hz");
+        }
+
+        /// <summary>Stop microphone capture and release device.</summary>
+        public void StopCapture()
+        {
+            if (!IsCaptureRunning) return;
+
+            // TODO: Microphone.End(MicDeviceName);
+            _micClip = null;
+            IsCaptureRunning = false;
+            IsTransmitting = false;
+
+            Debug.Log("[VoiceChat] Capture stopped.");
+        }
+
+        /// <summary>Mute/unmute local microphone (other players will hear silence).</summary>
+        public void SetMute(bool muted)
+        {
+            IsMuted = muted;
+            Debug.Log($"[VoiceChat] {(muted ? "Muted" : "Unmuted")}");
+        }
+
+        public void ToggleMute() => SetMute(!IsMuted);
+
+        /// <summary>
+        /// Feed received encoded audio bytes to the playback pipeline.
+        /// Call this from NetworkManager.OnDataReceived when the packet type
+        /// indicates voice data.
+        /// TODO: decode and schedule on PlaybackSource.
+        /// </summary>
+        public void ReceiveVoicePacket(byte[] encodedData)
+        {
+            if (PlaybackSource == null) return;
+            // TODO: decode audio (Opus or raw PCM) and play via PlaybackSource
+            Debug.Log($"[VoiceChat] Received voice packet: {encodedData?.Length ?? 0} bytes (not yet decoded)");
+        }
+
+        // ---- Private helpers ----
+        private bool ShouldTransmit()
+        {
+            if (IsMuted) return false;
+            if (Mode == VoiceChatMode.AlwaysOn) return true;
+
+            // Push-to-talk
+#if HAS_META_XR
+            return OVRInput.Get(PushToTalkButton);
+#else
+            return Input.GetKey(KeyCode.V);  // fallback: V key in editor
+#endif
+        }
+
+        private void ProcessMicInput()
+        {
+            if (_micClip == null) return;
+
+            int micPos = Microphone.GetPosition(
+                string.IsNullOrEmpty(MicDeviceName) ? null : MicDeviceName);
+
+            if (micPos == _lastMicPosition) return;
+
+            // Wrap-around read
+            int samples;
+            if (micPos > _lastMicPosition)
+            {
+                samples = micPos - _lastMicPosition;
+            }
+            else
+            {
+                samples = _micClip.samples - _lastMicPosition + micPos;
+            }
+
+            if (samples <= 0) return;
+
+            if (_sampleBuffer == null || _sampleBuffer.Length < samples)
+                _sampleBuffer = new float[samples];
+
+            _micClip.GetData(_sampleBuffer, _lastMicPosition);
+            _lastMicPosition = micPos;
+
+            FeedLipSync(_sampleBuffer, samples);
+            TransmitAudio(_sampleBuffer, samples);
+        }
+
+        private void FeedLipSync(float[] samples, int count)
+        {
+            if (!EnableLipSync || LipSyncContext == null) return;
+
+#if HAS_META_XR
+            // OVRLipSyncContext.ProcessAudioSamplesRaw exists in Meta XR Audio SDK.
+            // We use reflection to avoid a hard compile dependency.
+            var method = LipSyncContext.GetType().GetMethod("ProcessAudioSamplesRaw");
+            if (method != null)
+            {
+                // Trim array if needed
+                float[] chunk = samples;
+                if (samples.Length != count)
+                {
+                    chunk = new float[count];
+                    System.Array.Copy(samples, chunk, count);
+                }
+                method.Invoke(LipSyncContext, new object[] { chunk, 1 });
+            }
+#endif
+        }
+
+        private void TransmitAudio(float[] samples, int count)
+        {
+            // TODO: encode samples (Opus recommended) and send via NetworkManager.
+            // Stub: just log once every ~5 seconds to show the pipeline is running.
+            // NetworkManager.Instance?.SendUnreliable(encodedBytes, -1);
+        }
+
+        private void AutoDetectLipSync()
+        {
+            if (!EnableLipSync || LipSyncContext != null) return;
+
+#if HAS_META_XR
+            // Try to find OVRLipSyncContext anywhere on this GameObject or children
+            var ctx = GetComponentInChildren<OVRLipSyncContext>();
+            if (ctx != null)
+            {
+                LipSyncContext = ctx;
+                Debug.Log("[VoiceChat] OVRLipSyncContext auto-detected.");
+            }
+#endif
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- **NetworkManager** -- singleton abstraction over transport (INetworkTransport interface). Ships with LocalLoopbackTransport for solo testing. Swap to Photon/Netcode by calling `SetTransport()`.
- **NetworkPlayer** -- captures OVR head + hand anchors each FixedUpdate, serializes into compact 93-byte `PlayerPoseSnapshot` packets (binary, no JSON), sends via NetworkManager at configurable Hz (default 30).
- **NetworkInterpolator** -- sorted snapshot buffer, renders at `now - interpolationDelay` (default 50 ms), Lerp/Slerp between bracketing snapshots. Includes Editor gizmo for buffer visualization.
- **VoiceChat** -- push-to-talk or always-on modes. OVRLipSync fed via reflection (no hard compile dependency on Meta XR Audio). Photon Voice / Vivox stubs clearly marked with TODO.
- **LobbyUI** -- world-space legacy UI canvas (no TextMeshPro dependency). Create/Join room, player list with ready status, Leave. Billboards toward camera.

Closes #43

## Test plan

- [ ] Open `testbed.unity`
- [ ] Add empty GameObject, attach `NetworkManager` -- verify singleton pattern: only one instance survives play mode
- [ ] Add second GameObject, attach `NetworkPlayer` with `IsLocal = true` -- press Play, confirm `[NetworkManager] LocalLoopback: connected` in Console
- [ ] Add third GameObject, attach `NetworkPlayer` with `IsLocal = false, PlayerId = 0` + `NetworkInterpolator` -- verify remote player bones move (loopback reflects local poses)
- [ ] Add fourth GameObject, attach `LobbyUI` -- verify world-space panel appears in front of camera, Create/Join buttons respond, player row appears after connect
- [ ] Add `VoiceChat` to local player -- confirm no compile errors with or without `HAS_META_XR` defined

## Notes

- No existing files were modified.
- All scripts in namespace `Plaga44.Networking`.
- `#if HAS_META_XR` guards all OVR API calls -- compiles clean without Meta XR SDK.
- Meta .meta files will be auto-generated by Unity on first import.
Closes #43