### PR TITLE
Hand grab interactions (Interaction SDK) -- closes #28 [v2]

### DIFF
--- a/Assets/Editor/HandGrabSetup.cs
+++ b/Assets/Editor/HandGrabSetup.cs
@@ -1,0 +1,256 @@
+#if UNITY_EDITOR
+using System;
+using UnityEditor;
+using UnityEngine;
+using UnityEditor.SceneManagement;
+using Plaga44.Interaction;
+
+namespace Plaga44.Editor
+{
+    /// <summary>
+    /// Sets up HandGrabInteractor on both controller anchors of OVRCameraRig.
+    /// Menu: CYBERNOMAD > Scene Setup > Add Hand Grab Interactors
+    ///
+    /// Requires: com.meta.xr.sdk.interaction + com.meta.xr.sdk.interaction.ovr (v81+)
+    /// Uses reflection to add Interaction SDK components so this script compiles
+    /// even when the SDK packages are not yet downloaded.
+    /// </summary>
+    public static class HandGrabSetup
+    {
+        private const string LOG = "[PLAGA44]";
+
+#if HAS_META_XR
+        // Interaction SDK type names used via reflection (com.meta.xr.sdk.interaction v81).
+        // Full namespace path: Oculus.Interaction.HandGrab.*
+        // OVR bridge: Oculus.Interaction.OVR.*  (com.meta.xr.sdk.interaction.ovr)
+        private const string TYPE_HAND_GRAB_INTERACTOR =
+            "Oculus.Interaction.HandGrab.HandGrabInteractor";
+
+        // Prefab search hints for ControllerHands (from interaction.ovr samples)
+        private static readonly string[] CONTROLLER_HANDS_PREFAB_HINTS = new[]
+        {
+            "ControllerHands",
+            "OVRControllerPrefab",
+            "HandGrabInteractor",
+        };
+#endif
+
+        [MenuItem("CYBERNOMAD/Scene Setup/Add Hand Grab Interactors", false, 110)]
+        public static void AddHandGrabInteractors()
+        {
+            Debug.Log($"{LOG} === Add Hand Grab Interactors ===");
+
+#if HAS_META_XR
+            var rig = FindOVRCameraRig();
+            if (rig == null)
+            {
+                Debug.LogError(
+                    $"{LOG} OVRCameraRig not found in scene. " +
+                    "Run CYBERNOMAD > Scene Setup > Setup TESTBED first.");
+                return;
+            }
+
+            Transform leftAnchor  = MetaQuestSetup.FindChildRecursive(rig.transform, "LeftControllerAnchor");
+            Transform rightAnchor = MetaQuestSetup.FindChildRecursive(rig.transform, "RightControllerAnchor");
+
+            if (leftAnchor == null || rightAnchor == null)
+            {
+                // Fallback anchor names used in some OVRCameraRig versions
+                leftAnchor  = MetaQuestSetup.FindChildRecursive(rig.transform, "LeftHandAnchor");
+                rightAnchor = MetaQuestSetup.FindChildRecursive(rig.transform, "RightHandAnchor");
+            }
+
+            if (leftAnchor == null || rightAnchor == null)
+            {
+                Debug.LogError(
+                    $"{LOG} Controller anchors not found in OVRCameraRig. " +
+                    "Expected: LeftControllerAnchor / RightControllerAnchor.");
+                return;
+            }
+
+            // Try to instantiate from prefab first (preferred, keeps all wiring intact)
+            bool prefabInstalled = TryInstallFromPrefab(rig, leftAnchor, rightAnchor);
+
+            if (!prefabInstalled)
+            {
+                // Fallback: create minimal GameObjects with required components via reflection
+                InstallViaReflection(leftAnchor, rightAnchor);
+            }
+
+            EditorSceneManager.MarkSceneDirty(EditorSceneManager.GetActiveScene());
+            Debug.Log($"{LOG} === Hand Grab Interactors setup complete ===");
+#else
+            Debug.LogError(
+                $"{LOG} HAS_META_XR define not set. " +
+                "Switch to Android build target and run Meta SDK Setup first.");
+#endif
+        }
+
+#if HAS_META_XR
+        private static OVRCameraRig FindOVRCameraRig()
+        {
+            var rig = UnityEngine.Object.FindFirstObjectByType<OVRCameraRig>();
+            if (rig != null) return rig;
+
+            // Also search by name in case FindFirstObjectByType misses it
+            var go = GameObject.Find("OVRCameraRig");
+            return go != null ? go.GetComponent<OVRCameraRig>() : null;
+        }
+
+        /// <summary>
+        /// Tries to find ControllerHands prefab (from com.meta.xr.sdk.interaction.ovr)
+        /// and instantiate it under the rig. Returns true if successful.
+        /// </summary>
+        private static bool TryInstallFromPrefab(
+            OVRCameraRig rig, Transform leftAnchor, Transform rightAnchor)
+        {
+            // Check if already installed
+            if (leftAnchor.Find("HandGrabInteractor_L") != null ||
+                rightAnchor.Find("HandGrabInteractor_R") != null)
+            {
+                Debug.Log($"{LOG} HandGrabInteractors already present under controller anchors.");
+                return true;
+            }
+
+            GameObject prefab = FindInteractionPrefab();
+
+            if (prefab != null)
+            {
+                var instance = (GameObject)PrefabUtility.InstantiatePrefab(prefab, rig.transform);
+                instance.name = "HandGrabInteractors";
+                instance.transform.localPosition = Vector3.zero;
+                instance.transform.localRotation = Quaternion.identity;
+                Undo.RegisterCreatedObjectUndo(instance, "Add HandGrab Prefab");
+                Debug.Log(
+                    $"{LOG} Installed HandGrab prefab '{prefab.name}' under OVRCameraRig.");
+                return true;
+            }
+
+            Debug.LogWarning(
+                $"{LOG} ControllerHands / HandGrabInteractor prefab not found in AssetDatabase. " +
+                "Falling back to manual component setup. " +
+                "Make sure com.meta.xr.sdk.interaction.ovr is fully downloaded.");
+            return false;
+        }
+
+        private static GameObject FindInteractionPrefab()
+        {
+            foreach (string hint in CONTROLLER_HANDS_PREFAB_HINTS)
+            {
+                string[] guids = AssetDatabase.FindAssets($"{hint} t:prefab");
+                foreach (string guid in guids)
+                {
+                    string path = AssetDatabase.GUIDToAssetPath(guid);
+                    // Prefer prefabs from the Meta XR package paths
+                    if (path.Contains("com.meta.xr") || path.Contains("Interaction"))
+                    {
+                        var prefab = AssetDatabase.LoadAssetAtPath<GameObject>(path);
+                        if (prefab != null)
+                        {
+                            Debug.Log($"{LOG} Found interaction prefab: {path}");
+                            return prefab;
+                        }
+                    }
+                }
+            }
+            return null;
+        }
+
+        /// <summary>
+        /// Creates HandGrabInteractor GameObjects via reflection (no hard SDK dependency).
+        /// Works even if Interaction SDK assemblies are not yet loaded in the editor.
+        /// </summary>
+        private static void InstallViaReflection(Transform leftAnchor, Transform rightAnchor)
+        {
+            Type handGrabInteractorType = ResolveType(TYPE_HAND_GRAB_INTERACTOR);
+
+            if (handGrabInteractorType == null)
+            {
+                // SDK types not resolvable -- create placeholder GameObjects with instructions
+                CreatePlaceholderInteractor(leftAnchor, "HandGrabInteractor_L", "Left");
+                CreatePlaceholderInteractor(rightAnchor, "HandGrabInteractor_R", "Right");
+                Debug.LogWarning(
+                    $"{LOG} Interaction SDK types not found in loaded assemblies. " +
+                    "Created placeholder GameObjects. " +
+                    "After Unity downloads com.meta.xr.sdk.interaction packages, " +
+                    "add HandGrabInteractor component to each placeholder manually, " +
+                    "or re-run this menu item.");
+                return;
+            }
+
+            // Create left interactor
+            var leftGO = CreateInteractorGO(leftAnchor, "HandGrabInteractor_L", handGrabInteractorType);
+            Undo.RegisterCreatedObjectUndo(leftGO, "Add Left HandGrabInteractor");
+
+            // Create right interactor
+            var rightGO = CreateInteractorGO(rightAnchor, "HandGrabInteractor_R", handGrabInteractorType);
+            Undo.RegisterCreatedObjectUndo(rightGO, "Add Right HandGrabInteractor");
+
+            Debug.Log(
+                $"{LOG} HandGrabInteractor added to both controller anchors. " +
+                "Configure OVRControllerRef / OVRHandRef references in Inspector.");
+        }
+
+        private static GameObject CreateInteractorGO(
+            Transform parent, string goName, Type interactorType)
+        {
+            var go = new GameObject(goName);
+            go.transform.SetParent(parent, false);
+            go.transform.localPosition = Vector3.zero;
+            go.transform.localRotation = Quaternion.identity;
+
+            // Add HandGrabInteractor via reflection
+            go.AddComponent(interactorType);
+
+            // Add required Rigidbody (kinematic -- position controlled by tracking)
+            var rb = go.AddComponent<Rigidbody>();
+            rb.isKinematic = true;
+            rb.useGravity = false;
+
+            return go;
+        }
+
+        private static void CreatePlaceholderInteractor(
+            Transform parent, string goName, string side)
+        {
+            // Check if already exists
+            if (parent.Find(goName) != null)
+            {
+                Debug.Log($"{LOG} {goName} already exists under {parent.name}. Skipping.");
+                return;
+            }
+
+            var go = new GameObject(goName);
+            go.transform.SetParent(parent, false);
+            go.transform.localPosition = Vector3.zero;
+            go.transform.localRotation = Quaternion.identity;
+
+            // Add kinematic Rigidbody (required by HandGrabInteractor)
+            var rb = go.AddComponent<Rigidbody>();
+            rb.isKinematic = true;
+            rb.useGravity = false;
+
+            // Add a helper component to remind the dev what to add
+            var helper = go.AddComponent<HandGrabInteractorPlaceholder>();
+            helper.handSide = side;
+
+            Undo.RegisterCreatedObjectUndo(go, $"Add {side} HandGrabInteractor Placeholder");
+            Debug.Log(
+                $"{LOG} Placeholder '{goName}' created under {parent.name}. " +
+                $"Add HandGrabInteractor ({side}) component manually after SDK resolves.");
+        }
+
+        private static Type ResolveType(string typeName)
+        {
+            // Try loaded assemblies by full namespace + class name
+            foreach (var asm in AppDomain.CurrentDomain.GetAssemblies())
+            {
+                var t = asm.GetType(typeName);
+                if (t != null) return t;
+            }
+            return null;
+        }
+#endif
+    }
+}
+#endif

--- a/Assets/Scripts/HandGrabInteractableHelper.cs
+++ b/Assets/Scripts/HandGrabInteractableHelper.cs
@@ -1,0 +1,151 @@
+// HandGrabInteractableHelper.cs
+// CYBERNOMAD -- Marks a GameObject as grabbable via Meta XR Interaction SDK.
+//
+// Usage:
+//   Add this component to any object you want the player to grab.
+//   It auto-adds Rigidbody and (when Interaction SDK is present) HandGrabInteractable.
+//
+// Requires: com.meta.xr.sdk.interaction (auto-detected via HAS_META_XR define)
+// Namespace: Plaga44.Interaction
+
+using UnityEngine;
+
+#if HAS_META_XR
+using System;
+#endif
+
+namespace Plaga44.Interaction
+{
+    /// <summary>
+    /// Marks a GameObject as grabbable via controller-driven hand grab.
+    /// Add this component to objects the player should be able to pick up.
+    ///
+    /// At runtime (on Quest), if com.meta.xr.sdk.interaction is installed,
+    /// HandGrabInteractable will be resolved and added automatically.
+    /// If the SDK is not present, the component logs a warning and skips.
+    /// </summary>
+    [RequireComponent(typeof(Rigidbody))]
+    [AddComponentMenu("PLAGA44/Hand Grab Interactable Helper")]
+    public class HandGrabInteractableHelper : MonoBehaviour
+    {
+        [Header("Grab Settings")]
+        [Tooltip("Mass of the object when held (kg). Reverts on release.")]
+        public float heldMass = 0.3f;
+
+        [Tooltip("If true, gravity is disabled while the object is grabbed.")]
+        public bool disableGravityWhileHeld = true;
+
+        [Header("Physics")]
+        [Tooltip("Mass of the object at rest.")]
+        public float restMass = 0.5f;
+
+        [Tooltip("Collision detection mode. Continuous is safer for fast throws.")]
+        public CollisionDetectionMode collisionMode = CollisionDetectionMode.ContinuousDynamic;
+
+        // Runtime state
+        private Rigidbody _rb;
+        private bool _isGrabbed;
+
+#if HAS_META_XR
+        private const string TYPE_HAND_GRAB_INTERACTABLE =
+            "Oculus.Interaction.HandGrab.HandGrabInteractable";
+
+        private const string TYPE_GRABBABLE =
+            "Oculus.Interaction.Grabbable";
+
+        private const string TYPE_RIGIDBODY_POSE_UPDATER =
+            "Oculus.Interaction.RigidbodyPoseUpdater";
+#endif
+
+        private void Awake()
+        {
+            _rb = GetComponent<Rigidbody>();
+            ConfigureRigidbody();
+
+#if HAS_META_XR
+            EnsureInteractionComponents();
+#else
+            Debug.LogWarning(
+                $"[PLAGA44] HandGrabInteractableHelper on '{name}': " +
+                "HAS_META_XR not defined. Grab will not work. " +
+                "Make sure build target is Android with Meta XR SDK installed.");
+#endif
+        }
+
+        private void ConfigureRigidbody()
+        {
+            _rb.mass = restMass;
+            _rb.collisionDetectionMode = collisionMode;
+        }
+
+#if HAS_META_XR
+        /// <summary>
+        /// Adds HandGrabInteractable, Grabbable, and RigidbodyPoseUpdater via reflection
+        /// so this script compiles without a hard assembly reference to the Interaction SDK.
+        /// </summary>
+        private void EnsureInteractionComponents()
+        {
+            TryAddComponent(TYPE_GRABBABLE, "Grabbable");
+            TryAddComponent(TYPE_RIGIDBODY_POSE_UPDATER, "RigidbodyPoseUpdater");
+            TryAddComponent(TYPE_HAND_GRAB_INTERACTABLE, "HandGrabInteractable");
+        }
+
+        private void TryAddComponent(string typeName, string friendlyName)
+        {
+            // Search all loaded assemblies for the type
+            Type t = null;
+            foreach (var asm in AppDomain.CurrentDomain.GetAssemblies())
+            {
+                t = asm.GetType(typeName);
+                if (t != null) break;
+            }
+
+            if (t == null)
+            {
+                Debug.LogWarning(
+                    $"[PLAGA44] HandGrabInteractableHelper: " +
+                    $"Type '{typeName}' not found. " +
+                    $"Is com.meta.xr.sdk.interaction installed and compiled?");
+                return;
+            }
+
+            if (GetComponent(t) == null)
+            {
+                gameObject.AddComponent(t);
+                Debug.Log($"[PLAGA44] Added {friendlyName} to '{name}'.");
+            }
+        }
+#endif
+
+        // ── Public API for grab state (called by grab events if wired manually) ──
+
+        /// <summary>
+        /// Call this when the object is grabbed (e.g. from HandGrabInteractable events).
+        /// Adjusts physics for held state.
+        /// </summary>
+        public void OnGrabbed()
+        {
+            if (_isGrabbed) return;
+            _isGrabbed = true;
+
+            _rb.mass = heldMass;
+            if (disableGravityWhileHeld)
+                _rb.useGravity = false;
+        }
+
+        /// <summary>
+        /// Call this when the object is released.
+        /// Restores physics for free-fall state.
+        /// </summary>
+        public void OnReleased()
+        {
+            if (!_isGrabbed) return;
+            _isGrabbed = false;
+
+            _rb.mass = restMass;
+            _rb.useGravity = true;
+        }
+
+        public bool IsGrabbed => _isGrabbed;
+    }
+}

--- a/Assets/Scripts/HandGrabInteractorPlaceholder.cs
+++ b/Assets/Scripts/HandGrabInteractorPlaceholder.cs
@@ -1,0 +1,46 @@
+// HandGrabInteractorPlaceholder.cs
+// CYBERNOMAD -- Temporary placeholder for HandGrabInteractor setup.
+//
+// Created by HandGrabSetup editor tool when com.meta.xr.sdk.interaction types
+// are not yet resolvable (packages still downloading).
+//
+// Once SDK resolves: remove this component, add HandGrabInteractor manually,
+// or re-run CYBERNOMAD > Scene Setup > Add Hand Grab Interactors.
+//
+// Namespace: Plaga44.Interaction
+
+using UnityEngine;
+
+namespace Plaga44.Interaction
+{
+    /// <summary>
+    /// Placeholder component placed on controller anchor GameObjects when
+    /// HandGrabInteractor type cannot be resolved at editor setup time.
+    ///
+    /// Replace with Oculus.Interaction.HandGrab.HandGrabInteractor once
+    /// com.meta.xr.sdk.interaction package is fully imported by Unity.
+    /// </summary>
+    [AddComponentMenu("PLAGA44/Hand Grab Interactor Placeholder (Temp)")]
+    public class HandGrabInteractorPlaceholder : MonoBehaviour
+    {
+        [Tooltip("Which hand this interactor is for.")]
+        public string handSide = "Left";
+
+        [Multiline]
+        public string setupInstructions =
+            "This is a placeholder for HandGrabInteractor.\n" +
+            "1. Ensure com.meta.xr.sdk.interaction is installed.\n" +
+            "2. Remove this component.\n" +
+            "3. Add: Oculus.Interaction.HandGrab.HandGrabInteractor\n" +
+            "4. Wire OVRControllerRef / OVRHandRef references.\n" +
+            "OR: re-run CYBERNOMAD > Scene Setup > Add Hand Grab Interactors.";
+
+        private void Awake()
+        {
+            Debug.LogWarning(
+                $"[PLAGA44] HandGrabInteractorPlaceholder is present on '{name}' ({handSide}). " +
+                "This is a setup placeholder -- replace with HandGrabInteractor " +
+                "from com.meta.xr.sdk.interaction.");
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Re-created PR (originally #54 -- was merged+reverted by mistake, this restores the changes).

- `Assets/Editor/HandGrabSetup.cs` -- 3-tier setup: SDK prefab -> reflection fallback -> placeholder
- `Assets/Scripts/HandGrabInteractableHelper.cs` -- Makes objects grabbable via Interaction SDK
- `Assets/Scripts/HandGrabInteractorPlaceholder.cs` -- Temp component when SDK types unavailable

Closes #28