### PR TITLE
feat: Performance optimization - ASW, FFR, Dynamic Resolution (#89)

### DIFF
--- a/Assets/Editor/TestEnvironmentSetup.cs
+++ b/Assets/Editor/TestEnvironmentSetup.cs
@@ -319,6 +319,10 @@ namespace Plaga44.Editor
             if (player.GetComponent<HandCollisionIgnore>() == null)
                 player.AddComponent<HandCollisionIgnore>();
 
+            // Runtime performance optimization -- ASW, FFR, Dynamic Resolution
+            if (player.GetComponent<PerformanceConfig>() == null)
+                player.AddComponent<PerformanceConfig>();
+
             Debug.Log($"{LOG} OVRGrabber added to controller anchors.");
         }
 

--- a/Assets/Scripts/Core.meta
+++ b/Assets/Scripts/Core.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: dba95c71c4a34ba294c0726d0248166e
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Core/PerformanceConfig.cs
+++ b/Assets/Scripts/Core/PerformanceConfig.cs
@@ -1,0 +1,71 @@
+// PerformanceConfig.cs
+// CYBERNOMAD -- Runtime performance optimization for Quest 3.
+// Enables ASW, FFR, Dynamic Resolution via OVRManager API.
+// Add to OVRPlayerController root or any persistent GameObject.
+
+using UnityEngine;
+
+public class PerformanceConfig : MonoBehaviour
+{
+    [Header("Application SpaceWarp")]
+    [Tooltip("Synthesizes every other frame. ~2x GPU performance.")]
+    public bool enableASW = true;
+
+    [Header("Fixed Foveated Rendering")]
+    [Tooltip("Reduces GPU load at peripheral edges.")]
+    public bool enableFFR = true;
+    public OVRManager.FoveatedRenderingLevel ffrLevel = OVRManager.FoveatedRenderingLevel.HighTop;
+    public bool useDynamicFFR = true;
+
+    [Header("Dynamic Resolution")]
+    [Tooltip("Auto-scales render resolution when FPS drops. Configured on OVRManager instance.")]
+    public bool enableDynamicResolution = true;
+    [Range(0.5f, 1.0f)]
+    public float minResolutionScale = 0.7f;
+    [Range(0.8f, 1.6f)]
+    public float maxResolutionScale = 1.0f;
+
+    [Header("CPU/GPU Levels")]
+    [Tooltip("PowerSavings=0, SustainedLow=1, SustainedHigh=2, Boost=3")]
+    public OVRManager.ProcessorPerformanceLevel cpuLevel = OVRManager.ProcessorPerformanceLevel.SustainedHigh;
+    public OVRManager.ProcessorPerformanceLevel gpuLevel = OVRManager.ProcessorPerformanceLevel.SustainedHigh;
+
+    void Start()
+    {
+        ApplySettings();
+    }
+
+    public void ApplySettings()
+    {
+        // ASW (Application SpaceWarp)
+        OVRManager.SetSpaceWarp(enableASW);
+        Debug.Log($"[PLAGA44] PerformanceConfig: ASW={enableASW}");
+
+        // FFR (Fixed Foveated Rendering)
+        OVRManager.foveatedRenderingLevel = enableFFR ? ffrLevel : OVRManager.FoveatedRenderingLevel.Off;
+        OVRManager.useDynamicFoveatedRendering = enableFFR && useDynamicFFR;
+        Debug.Log($"[PLAGA44] PerformanceConfig: FFR={ffrLevel}, Dynamic={useDynamicFFR}");
+
+        // Dynamic Resolution -- instance property on OVRManager
+        var mgr = OVRManager.instance;
+        if (mgr != null)
+        {
+            mgr.enableDynamicResolution = enableDynamicResolution;
+            if (enableDynamicResolution)
+            {
+                mgr.minDynamicResolutionScale = minResolutionScale;
+                mgr.maxDynamicResolutionScale = maxResolutionScale;
+                Debug.Log($"[PLAGA44] PerformanceConfig: DynamicResolution min={minResolutionScale} max={maxResolutionScale}");
+            }
+        }
+        else
+        {
+            Debug.LogWarning("[PLAGA44] PerformanceConfig: OVRManager.instance not found -- dynamic resolution skipped.");
+        }
+
+        // CPU/GPU Performance Levels
+        OVRManager.suggestedCpuPerfLevel = cpuLevel;
+        OVRManager.suggestedGpuPerfLevel = gpuLevel;
+        Debug.Log($"[PLAGA44] PerformanceConfig: CPU={cpuLevel}, GPU={gpuLevel}");
+    }
+}

--- a/Assets/Scripts/Core/PerformanceConfig.cs.meta
+++ b/Assets/Scripts/Core/PerformanceConfig.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 027e190749434f0481a384e260af93ad
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary

- Adds `Assets/Scripts/Core/PerformanceConfig.cs` -- MonoBehaviour for runtime Quest 3 performance tuning
- Wires `PerformanceConfig` into `TestEnvironmentSetup` (auto-added to OVRPlayerController via Setup TESTBED)
- Verified all OVRManager API calls against SDK v81 source

## API corrections vs original spec

| Spec | Actual v81 API | Why |
|------|----------------|-----|
| `(OVRManager.ProcessorPerformanceLevel)cpuLevel` (int 0-5) | `OVRManager.ProcessorPerformanceLevel` enum directly | Enum has 4 named values (0=PowerSavings, 1=SustainedLow, 2=SustainedHigh, 3=Boost). Int cast from [Range(0,5)] would be wrong for values 4-5 |
| Dynamic resolution -- no accessor shown | `OVRManager.instance.enableDynamicResolution` + `minDynamicResolutionScale` + `maxDynamicResolutionScale` | Instance properties, not static |

## What was implemented

- **ASW**: `OVRManager.SetSpaceWarp(bool)` -- static, correct
- **FFR**: `OVRManager.foveatedRenderingLevel` (static property) + `OVRManager.useDynamicFoveatedRendering` (static property)
- **Dynamic Resolution**: `OVRManager.instance.enableDynamicResolution` + scale range (min 0.7, max 1.0 default)
- **CPU/GPU levels**: `OVRManager.suggestedCpuPerfLevel` / `suggestedGpuPerfLevel` with named enum (defaults to `SustainedHigh`)

## Test plan

- [ ] Open Unity 6, switch build target to Android (Quest)
- [ ] Run **CYBERNOMAD > Scene Setup > Setup TESTBED**
- [ ] Select OVRPlayerController in Hierarchy -- confirm `PerformanceConfig` component is present
- [ ] Check Inspector: ASW=true, FFR=true, FFR Level=HighTop, DynamicFFR=true, DynamicResolution=true, min=0.7, max=1.0, CPU/GPU=SustainedHigh
- [ ] Enter Play mode -- Console should show:
  - `[PLAGA44] PerformanceConfig: ASW=True`
  - `[PLAGA44] PerformanceConfig: FFR=HighTop, Dynamic=True`
  - `[PLAGA44] PerformanceConfig: DynamicResolution min=0.7 max=1`
  - `[PLAGA44] PerformanceConfig: CPU=SustainedHigh, GPU=SustainedHigh`
- [ ] If OVRManager.instance is null (editor without XR), expect warning: `PerformanceConfig: OVRManager.instance not found -- dynamic resolution skipped.`

Closes #89