### PR TITLE
feat: haptic feedback for grab, throw, and hit (#90)

### DIFF
--- a/Assets/Editor/TestEnvironmentSetup.cs
+++ b/Assets/Editor/TestEnvironmentSetup.cs
@@ -31,6 +31,7 @@ namespace Plaga44.Editor
             TargetFactory.AddTestTargets();
             AddSplashScreen();
             AddDebugHUD();
+            AddHapticFeedback();
 
             Selection.activeGameObject = player;
             UnityEditor.SceneManagement.EditorSceneManager.MarkSceneDirty(
@@ -267,8 +268,8 @@ namespace Plaga44.Editor
             rb.angularDamping = 2.0f;
             rb.collisionDetectionMode = CollisionDetectionMode.ContinuousSpeculative;
 
-            // OVRGrabbable -- grab points = both colliders
-            var grabbable = stone.AddComponent<OVRGrabbable>();
+            // RuntimeGrabbable -- subclass of OVRGrabbable with haptic feedback + null-safe Awake.
+            var grabbable = stone.AddComponent<RuntimeGrabbable>();
             var gso = new SerializedObject(grabbable);
             SetBool(gso, "m_allowOffhandGrab", true);
             var grabPointsProp = gso.FindProperty("m_grabPoints");
@@ -406,6 +407,23 @@ namespace Plaga44.Editor
             var go = new GameObject("VRInputDebug");
             go.AddComponent<VRInputDebug>();
             Undo.RegisterCreatedObjectUndo(go, "Add VRInputDebug");
+        }
+
+        // ---- HAPTICS ----
+
+        static void AddHapticFeedback()
+        {
+            // HapticFeedback is a singleton MonoBehaviour required for coroutine-based
+            // timed vibration pulses. One instance in scene is sufficient.
+            if (Object.FindFirstObjectByType<HapticFeedback>() != null)
+            {
+                Debug.Log($"{LOG} HapticFeedback already in scene.");
+                return;
+            }
+            var go = new GameObject("HapticFeedback");
+            go.AddComponent<HapticFeedback>();
+            Undo.RegisterCreatedObjectUndo(go, "Add HapticFeedback");
+            Debug.Log($"{LOG} HapticFeedback added.");
         }
 
         // ---- HELPERS ----

--- a/Assets/Scripts/Feedback/HapticFeedback.cs
+++ b/Assets/Scripts/Feedback/HapticFeedback.cs
@@ -1,0 +1,126 @@
+// HapticFeedback.cs
+// CYBERNOMAD -- Haptic feedback for VR interactions.
+// Phase 1: OVRInput.SetControllerVibration (works without Haptics SDK)
+// Phase 2: Meta Haptics SDK .haptic clips (future)
+//
+// Usage:
+//   HapticFeedback.Grab(controller);         // short pulse on grab
+//   HapticFeedback.Release(controller);      // sharp kick on throw release
+//   HapticFeedback.HitTarget(controller, zoneType);  // impact feedback
+//   HapticFeedback.HitMiss(controller);      // soft thud on wall/ground hit
+//   HapticFeedback.ThrowWindup(controller, intensity);  // continuous while winding up
+//   HapticFeedback.StopVibration(controller); // cut immediately
+//
+// Notes:
+// - OVRInput.SetControllerVibration(frequency, amplitude, controller)
+//   frequency and amplitude are 0..1, controller = OVRInput.Controller enum.
+// - Coroutines are used to auto-stop timed pulses.
+// - Instance is required for coroutines; static methods forward to it.
+
+using UnityEngine;
+using System.Collections;
+
+public class HapticFeedback : MonoBehaviour
+{
+    private static HapticFeedback _instance;
+
+    public static HapticFeedback Instance
+    {
+        get
+        {
+            if (_instance == null)
+                _instance = FindFirstObjectByType<HapticFeedback>();
+            return _instance;
+        }
+    }
+
+    private void Awake()
+    {
+        _instance = this;
+    }
+
+    // --- Public API ---
+
+    /// <summary>
+    /// Short pulse when picking up an object. 0.3f amplitude, 0.1s.
+    /// </summary>
+    public static void Grab(OVRInput.Controller controller)
+    {
+        Vibrate(controller, 0.3f, 0.3f, 0.1f);
+    }
+
+    /// <summary>
+    /// Sharp kick on throw release. 0.6f amplitude, 0.05s.
+    /// </summary>
+    public static void Release(OVRInput.Controller controller)
+    {
+        Vibrate(controller, 0.6f, 0.6f, 0.05f);
+    }
+
+    /// <summary>
+    /// Impact feedback when stone hits a target zone.
+    /// Amplitude and duration vary by anatomical zone.
+    /// </summary>
+    public static void HitTarget(OVRInput.Controller controller, string zone = "body")
+    {
+        float amp = zone == "head"  ? 1.0f :
+                    zone == "torso" ? 0.7f : 0.5f;
+        float dur = zone == "head"  ? 0.3f : 0.2f;
+        Vibrate(controller, amp, amp, dur);
+    }
+
+    /// <summary>
+    /// Soft thud when stone hits a non-target surface (ground, wall, etc.).
+    /// </summary>
+    public static void HitMiss(OVRInput.Controller controller)
+    {
+        Vibrate(controller, 0.15f, 0.15f, 0.08f);
+    }
+
+    /// <summary>
+    /// Continuous windup vibration scaled by hand velocity intensity (0..1).
+    /// Call every frame while charging a throw. Does NOT auto-stop -- call
+    /// StopVibration() or Release() when done.
+    /// </summary>
+    public static void ThrowWindup(OVRInput.Controller controller, float intensity)
+    {
+        float amp = Mathf.Lerp(0.05f, 0.5f, Mathf.Clamp01(intensity));
+        OVRInput.SetControllerVibration(amp, amp, controller);
+    }
+
+    /// <summary>
+    /// Immediately stop all vibration on the given controller.
+    /// </summary>
+    public static void StopVibration(OVRInput.Controller controller)
+    {
+        OVRInput.SetControllerVibration(0f, 0f, controller);
+    }
+
+    // --- Internal ---
+
+    /// <summary>
+    /// Start a timed vibration pulse via coroutine.
+    /// Falls back to a fire-and-forget if no Instance exists in scene.
+    /// </summary>
+    private static void Vibrate(OVRInput.Controller controller, float frequency, float amplitude, float duration)
+    {
+        if (Instance != null)
+        {
+            Instance.StartCoroutine(Instance.VibrateCoroutine(controller, frequency, amplitude, duration));
+        }
+        else
+        {
+            // No MonoBehaviour in scene -- just fire the vibration.
+            // It will run until the next SetControllerVibration(0,0,...) call.
+            Debug.LogWarning("[PLAGA44] HapticFeedback: no Instance in scene, vibration will not auto-stop.");
+            OVRInput.SetControllerVibration(frequency, amplitude, controller);
+        }
+    }
+
+    private IEnumerator VibrateCoroutine(OVRInput.Controller controller, float frequency, float amplitude, float duration)
+    {
+        OVRInput.SetControllerVibration(frequency, amplitude, controller);
+        yield return new WaitForSeconds(duration);
+        OVRInput.SetControllerVibration(0f, 0f, controller);
+    }
+}

--- a/Assets/Scripts/Gameplay/HitDetector.cs
+++ b/Assets/Scripts/Gameplay/HitDetector.cs
@@ -6,6 +6,7 @@ namespace Plaga44.Gameplay
     /// Attach to a projectile (stone, rock, etc.) that has a Rigidbody.
     /// On collision, checks whether the struck object is part of a HitTarget,
     /// calculates impact force (velocity * mass) and calls HitTarget.RegisterHit.
+    /// Also triggers haptic feedback on the controller that threw the stone.
     /// </summary>
     [RequireComponent(typeof(Rigidbody))]
     public class HitDetector : MonoBehaviour
@@ -16,21 +17,31 @@ namespace Plaga44.Gameplay
         public Transform thrower;
 
         private Rigidbody _rb;
+        private RuntimeGrabbable _grabbable;
 
         private void Awake()
         {
             _rb = GetComponent<Rigidbody>();
+            // Cache the grabbable so we can read LastGrabController on impact.
+            _grabbable = GetComponent<RuntimeGrabbable>();
         }
 
         private void OnCollisionEnter(Collision collision)
         {
             HitZone zone = collision.collider.GetComponent<HitZone>();
-            if (zone == null) return;
+
+            if (zone == null)
+            {
+                // Stone hit a non-target surface -- soft thud feedback.
+                TriggerMissHaptic();
+                return;
+            }
 
             HitTarget target = zone.GetOwner();
             if (target == null)
             {
                 Debug.LogWarning($"{LOG} HitZone on {collision.collider.name} has no parent HitTarget.");
+                TriggerMissHaptic();
                 return;
             }
 
@@ -38,6 +49,39 @@ namespace Plaga44.Gameplay
             Vector3 impactDir = _rb.linearVelocity.normalized;
 
             target.RegisterHit(zone, force, thrower, impactDir);
+
+            // Haptic: feedback on the hand that threw the stone.
+            string zoneName = zone.zoneType.ToString().ToLower();
+            // Map HitZoneType names to HapticFeedback zone strings.
+            // Head -> "head", Body -> "torso", arms/legs -> "limb"
+            string hapticZone = zoneName == "head"  ? "head"  :
+                                zoneName == "body"  ? "torso" : "limb";
+            OVRInput.Controller ctrl = GetThrowerController();
+            HapticFeedback.HitTarget(ctrl, hapticZone);
+        }
+
+        /// <summary>
+        /// Gets the OVRInput.Controller that last held this stone.
+        /// Falls back to Controller.Active if no RuntimeGrabbable is present.
+        /// </summary>
+        private OVRInput.Controller GetThrowerController()
+        {
+            if (_grabbable != null && _grabbable.LastGrabController != OVRInput.Controller.None)
+                return _grabbable.LastGrabController;
+            return OVRInput.Controller.Active;
+        }
+
+        /// <summary>
+        /// Triggers soft-thud haptic when the stone hits a non-target surface.
+        /// Only fires once (first collision) to avoid rapid spam.
+        /// </summary>
+        private bool _missFired;
+
+        private void TriggerMissHaptic()
+        {
+            if (_missFired) return;
+            _missFired = true;
+            HapticFeedback.HitMiss(GetThrowerController());
         }
     }
 }

--- a/Assets/Scripts/RuntimeGrabbable.cs
+++ b/Assets/Scripts/RuntimeGrabbable.cs
@@ -13,6 +13,16 @@ using UnityEngine;
 
 public class RuntimeGrabbable : OVRGrabbable
 {
+    // Controller that last grabbed this object -- used for haptic feedback on release/hit.
+    // Determined at grab time via OVRInput.GetActiveController().
+    private OVRInput.Controller _lastGrabController = OVRInput.Controller.None;
+
+    /// <summary>
+    /// Returns the controller that is currently (or was last) holding this object.
+    /// Used by HitDetector to route haptic feedback to the correct hand.
+    /// </summary>
+    public OVRInput.Controller LastGrabController => _lastGrabController;
+
     /// <summary>
     /// Sets m_allowOffhandGrab (protected in base, no public setter).
     /// </summary>
@@ -45,10 +55,17 @@ public class RuntimeGrabbable : OVRGrabbable
     {
         base.GrabBegin(hand, grabPoint);
         SetPlayerCollision(ignore: true);
+
+        // Determine which controller just grabbed via active controller at grab moment.
+        // OVRGrabber.m_controller is protected so we can't access it directly from here.
+        // The hand trigger that fired GrabBegin IS the active controller.
+        _lastGrabController = OVRInput.GetActiveController();
+        HapticFeedback.Grab(_lastGrabController);
     }
 
     public override void GrabEnd(Vector3 linearVelocity, Vector3 angularVelocity)
     {
+        HapticFeedback.Release(_lastGrabController);
         SetPlayerCollision(ignore: false);
         base.GrabEnd(linearVelocity, angularVelocity);
     }


### PR DESCRIPTION
## Summary

- **HapticFeedback.cs** -- new singleton MonoBehaviour with static API using `OVRInput.SetControllerVibration`
- **RuntimeGrabbable.cs** -- `Grab()` on grab, `Release()` on throw release, caches last controller via `OVRInput.GetActiveController()`
- **HitDetector.cs** -- `HitTarget()` per zone (head/torso/limb), `HitMiss()` on first non-target collision
- **TestEnvironmentSetup.cs** -- adds `HapticFeedback` singleton, stones now use `RuntimeGrabbable` (was `OVRGrabbable`)

## Haptic Patterns

| Event | Frequency | Amplitude | Duration |
|-------|-----------|-----------|----------|
| Grab | 0.3 | 0.3 | 0.1s |
| Release (throw) | 0.6 | 0.6 | 0.05s |
| Hit head | 1.0 | 1.0 | 0.3s |
| Hit torso | 0.7 | 0.7 | 0.2s |
| Hit limb | 0.5 | 0.5 | 0.2s |
| Miss (ground/wall) | 0.15 | 0.15 | 0.08s |

## Architecture Notes

- **Controller detection**: `OVRGrabber.m_controller` is `protected` and not accessible from `RuntimeGrabbable`. Solution: `OVRInput.GetActiveController()` at grab moment -- the controller that just fired the grip trigger IS the active one.
- **LastGrabController** cached on `RuntimeGrabbable` -- `HitDetector` reads it on stone impact to route feedback to correct hand.
- **Phase 2 path**: `HapticFeedback.cs` header documents how to extend to Meta Haptics SDK `.haptic` clips when ready.

## Test Plan

1. Checkout `wrk4/haptic-feedback` in testbed (`C:\Users\boris\Desktop\PLAGA44\testbed\plaga44-unity`)
2. In Unity Editor: **CYBERNOMAD > Scene Setup > Setup TESTBED**
3. Build and deploy to Quest 3 (or use Link)
4. Test grab: Pick up stone with grip -- expect short 0.1s pulse
5. Test throw: Release stone with throw motion -- expect sharp 0.05s kick
6. Test hit target: Throw stone at mannequin head -- expect strong 0.3s pulse; body = medium; limbs = softer
7. Test miss: Throw stone at ground/wall -- expect single soft 0.08s thud (no repeat spam)
8. Verify HapticFeedback GameObject in scene hierarchy after Setup TESTBED