### PR TITLE
fix: rename duplicate HitZone enum to BodyZone in MorsCerebri

### DIFF
--- a/Assets/Scripts/Gameplay/MorsCerebri.cs
+++ b/Assets/Scripts/Gameplay/MorsCerebri.cs
@@ -5,10 +5,10 @@ namespace Plaga44.Gameplay
 {
     /// <summary>
     /// Mors Cerebri -- "brain death". MonoBehaviour placed on a target (enemy root).
-    /// Listens for hit events from HitDetector. If HitZone == Head and
+    /// Listens for hit events from HitDetector. If BodyZone == Head and
     /// incoming force >= forceThreshold, triggers ragdoll death sequence.
     ///
-    /// Wiring: HitDetector calls OnHit(HitData) on this component.
+    /// Wiring: HitDetector calls OnHit(HitData) on this component (BodyZone enum for zone ID).
     /// Requires: RagdollController on the same GameObject.
     /// </summary>
     [RequireComponent(typeof(RagdollController))]
@@ -43,7 +43,7 @@ namespace Plaga44.Gameplay
         public void OnHit(HitData data)
         {
             if (_isDead) return;
-            if (data.zone != HitZone.Head) return;
+            if (data.zone != BodyZone.Head) return;
             if (data.force < forceThreshold) return;
 
             Die(data);
@@ -72,7 +72,7 @@ namespace Plaga44.Gameplay
     // -------------------------------------------------------------------------
 
     /// <summary>Body zone identifier for hit detection routing.</summary>
-    public enum HitZone
+    public enum BodyZone
     {
         None,
         Head,
@@ -88,7 +88,7 @@ namespace Plaga44.Gameplay
     public struct HitData
     {
         /// <summary>Which body zone was struck.</summary>
-        public HitZone zone;
+        public BodyZone zone;
 
         /// <summary>Magnitude of impact force (kg*m/s or arbitrary game units).</summary>
         public float force;
@@ -99,7 +99,7 @@ namespace Plaga44.Gameplay
         /// <summary>World-space point of impact.</summary>
         public Vector3 hitPoint;
 
-        public HitData(HitZone zone, float force, Vector3 direction, Vector3 hitPoint)
+        public HitData(BodyZone zone, float force, Vector3 direction, Vector3 hitPoint)
         {
             this.zone      = zone;
             this.force     = force;


### PR DESCRIPTION
## Problem

`MorsCerebri.cs` defines `enum HitZone` in namespace `Plaga44.Gameplay`, which collides with `class HitZone` in `HitZone.cs` (same namespace). This causes CS0101: "The namespace 'Plaga44.Gameplay' already contains a definition for 'HitZone'".

## Fix

- Renamed `enum HitZone` to `enum BodyZone` in `MorsCerebri.cs`
- Updated all references: `HitData.zone` field type, `OnHit()` comparison, `HitData` constructor parameter
- Updated class docstring to reflect the new enum name

## Scope

Only `MorsCerebri.cs` was changed. The `HitZone` class in `HitZone.cs` and all files referencing it (HitDetector, HitTarget, VRScoreboard) remain unchanged -- they correctly reference the MonoBehaviour class, not the enum.

## Code Review Notes

Additional issues found during review (filed as separate issues):
- `SplashScreen` class has no namespace, shadows `UnityEngine.SplashScreen`
- `HitZoneType` enum defined in both `Plaga44.Gameplay` and `Plaga44.Rules` (different namespaces, but confusing)