### PR TITLE
fix: Wrap CharacterController-referencing scripts in Plaga44 namespaces (#108)

### DIFF
--- a/Assets/Editor/RuleImporter.cs
+++ b/Assets/Editor/RuleImporter.cs
@@ -164,7 +164,7 @@ namespace Plaga44.Editor
 
                 // Apply data.
                 rule.sourceObjectType = ParseEnum<ObjectType>(entry.source, ObjectType.Any);
-                rule.hitZone          = ParseEnum<HitZoneType>(entry.hitZone, HitZoneType.Any);
+                rule.hitZone          = ParseEnum<BodyRegion>(entry.hitZone, BodyRegion.Any);
                 rule.forceThreshold   = entry.threshold;
                 rule.resultEffect     = ParseEnum<CombatEffectType>(entry.effect, CombatEffectType.None);
                 rule.stunDuration     = entry.stunDuration;

--- a/Assets/Editor/TestEnvironmentSetup.cs
+++ b/Assets/Editor/TestEnvironmentSetup.cs
@@ -1,5 +1,7 @@
 #if UNITY_EDITOR
 using Plaga44.AI;
+using Plaga44.Core;
+using Plaga44.Interaction;
 using Plaga44.UI;
 using UnityEditor;
 using UnityEngine;

--- a/Assets/PLAGA44-BASE.unity
+++ b/Assets/PLAGA44-BASE.unity
@@ -5052,7 +5052,7 @@ MonoBehaviour:
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fc357ab418efed144aef741408dd8c65, type: 3}
   m_Name: 
-  m_EditorClassIdentifier: Assembly-CSharp::HandCollisionIgnore
+  m_EditorClassIdentifier: Assembly-CSharp::Plaga44.Core.HandCollisionIgnore
 --- !u!4 &973012411 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 416152, guid: 81d633455a8cc814e89ff68eb1deb8e7, type: 3}

--- a/Assets/Scenes/PLAGA44_Demo.unity
+++ b/Assets/Scenes/PLAGA44_Demo.unity
@@ -591,7 +591,7 @@ MonoBehaviour:
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fc357ab418efed144aef741408dd8c65, type: 3}
   m_Name: 
-  m_EditorClassIdentifier: Assembly-CSharp::HandCollisionIgnore
+  m_EditorClassIdentifier: Assembly-CSharp::Plaga44.Core.HandCollisionIgnore
 --- !u!1001 &223055972
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/PLAGA44_Demo.unity.bak
+++ b/Assets/Scenes/PLAGA44_Demo.unity.bak
@@ -6520,7 +6520,7 @@ MonoBehaviour:
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fc357ab418efed144aef741408dd8c65, type: 3}
   m_Name: 
-  m_EditorClassIdentifier: Assembly-CSharp::HandCollisionIgnore
+  m_EditorClassIdentifier: Assembly-CSharp::Plaga44.Core.HandCollisionIgnore
 --- !u!4 &1501094032 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 482042, guid: 506eda1dc7aad5742b90e680c7fb5ed3, type: 3}

--- a/Assets/Scripts/Core/SprintModifier.cs
+++ b/Assets/Scripts/Core/SprintModifier.cs
@@ -4,6 +4,8 @@
 
 using UnityEngine;
 
+namespace Plaga44.Core
+{
 public class SprintModifier : MonoBehaviour
 {
     [Header("Sprint")]
@@ -117,3 +119,4 @@ public class SprintModifier : MonoBehaviour
         return true;
     }
 }
+} // namespace Plaga44.Core

--- a/Assets/Scripts/Gameplay/HitDetector.cs
+++ b/Assets/Scripts/Gameplay/HitDetector.cs
@@ -1,3 +1,4 @@
+using Plaga44.Interaction;
 using UnityEngine;
 
 namespace Plaga44.Gameplay

--- a/Assets/Scripts/HandCollisionIgnore.cs
+++ b/Assets/Scripts/HandCollisionIgnore.cs
@@ -6,6 +6,8 @@
 
 using UnityEngine;
 
+namespace Plaga44.Core
+{
 public class HandCollisionIgnore : MonoBehaviour
 {
     void Start()
@@ -39,3 +41,4 @@ public class HandCollisionIgnore : MonoBehaviour
         Debug.Log($"[PLAGA44] HandCollisionIgnore: {count} colliders now ignore CharacterController.");
     }
 }
+} // namespace Plaga44.Core

--- a/Assets/Scripts/Rules/CombatRule.cs
+++ b/Assets/Scripts/Rules/CombatRule.cs
@@ -18,10 +18,12 @@ namespace Plaga44.Rules
     }
 
     /// <summary>
-    /// Enum of hit zones on the target body.
+    /// Abstract body region categories for combat rule matching.
     /// Maps to Neo4j HitZone nodes.
+    /// Unlike Gameplay.HitZoneType (granular anatomical zones), these are
+    /// broad regions used as rule conditions with wildcard support.
     /// </summary>
-    public enum HitZoneType
+    public enum BodyRegion
     {
         Any = 0,
         Head = 1,
@@ -46,8 +48,8 @@ namespace Plaga44.Rules
         [Tooltip("Type of object that must cause the hit. Use Any to match all objects.")]
         public ObjectType sourceObjectType = ObjectType.Any;
 
-        [Tooltip("Body zone that must be hit. Use Any to match all zones.")]
-        public HitZoneType hitZone = HitZoneType.Any;
+        [Tooltip("Body region that must be hit. Use Any to match all regions.")]
+        public BodyRegion hitZone = BodyRegion.Any;
 
         [Tooltip("Minimum force (in Newtons) required to trigger this rule.")]
         [Min(0f)]
@@ -76,12 +78,12 @@ namespace Plaga44.Rules
 
         /// <summary>
         /// Returns true if this rule matches the given source, zone, and force.
-        /// ObjectType.Any and HitZoneType.Any act as wildcards.
+        /// ObjectType.Any and BodyRegion.Any act as wildcards.
         /// </summary>
-        public bool Matches(ObjectType source, HitZoneType zone, float force)
+        public bool Matches(ObjectType source, BodyRegion zone, float force)
         {
             bool sourceMatch = (sourceObjectType == ObjectType.Any) || (sourceObjectType == source);
-            bool zoneMatch = (hitZone == HitZoneType.Any) || (hitZone == zone);
+            bool zoneMatch = (hitZone == BodyRegion.Any) || (hitZone == zone);
             bool forceMatch = force >= forceThreshold;
             return sourceMatch && zoneMatch && forceMatch;
         }

--- a/Assets/Scripts/Rules/CombatRuleEvaluator.cs
+++ b/Assets/Scripts/Rules/CombatRuleEvaluator.cs
@@ -37,7 +37,7 @@ namespace Plaga44.Rules
         /// <param name="source">What hit us.</param>
         /// <param name="zone">Where we were hit.</param>
         /// <param name="force">How hard (Newtons).</param>
-        public void ReceiveHit(ObjectType source, HitZoneType zone, float force)
+        public void ReceiveHit(ObjectType source, BodyRegion zone, float force)
         {
             if (ruleSet == null)
             {
@@ -93,13 +93,13 @@ namespace Plaga44.Rules
 
     /// <summary>
     /// Lightweight struct for passing hit data from HitDetector to CombatRuleEvaluator.
-    /// Create with: new HitEvent { source = ObjectType.Stone, zone = HitZoneType.Head, force = 12f }
+    /// Create with: new HitEvent { source = ObjectType.Stone, zone = BodyRegion.Head, force = 12f }
     /// </summary>
     [System.Serializable]
     public struct HitEvent
     {
         public ObjectType source;
-        public HitZoneType zone;
+        public BodyRegion zone;
         public float force;
     }
 }

--- a/Assets/Scripts/Rules/CombatRuleSet.cs
+++ b/Assets/Scripts/Rules/CombatRuleSet.cs
@@ -24,7 +24,7 @@ namespace Plaga44.Rules
         /// <param name="source">Object type that caused the hit (Stone, Fist, etc.)</param>
         /// <param name="zone">Hit zone on the target body (Head, Torso, etc.)</param>
         /// <param name="force">Impact force in Newtons.</param>
-        public CombatEffect Evaluate(ObjectType source, HitZoneType zone, float force)
+        public CombatEffect Evaluate(ObjectType source, BodyRegion zone, float force)
         {
             if (rules == null || rules.Length == 0)
             {
@@ -50,7 +50,7 @@ namespace Plaga44.Rules
         /// Evaluates and returns the first matching rule object (for debugging).
         /// Returns null if no rule matches.
         /// </summary>
-        public CombatRule FindMatchingRule(ObjectType source, HitZoneType zone, float force)
+        public CombatRule FindMatchingRule(ObjectType source, BodyRegion zone, float force)
         {
             if (rules == null) return null;
 

--- a/Assets/Scripts/RuntimeGrabbable.cs
+++ b/Assets/Scripts/RuntimeGrabbable.cs
@@ -11,6 +11,8 @@
 
 using UnityEngine;
 
+namespace Plaga44.Interaction
+{
 public class RuntimeGrabbable : OVRGrabbable
 {
     // Controller that last grabbed this object -- used for haptic feedback on release/hit.
@@ -91,3 +93,4 @@ public class RuntimeGrabbable : OVRGrabbable
         }
     }
 }
+} // namespace Plaga44.Interaction

--- a/Assets/Scripts/StoneSpawner.cs
+++ b/Assets/Scripts/StoneSpawner.cs
@@ -4,6 +4,7 @@
 // Compound collider: SphereCollider (grab point) + cross-shaped BoxColliders (physics).
 // OVRGrabbable.Awake() needs a Collider on root GO -- SphereCollider stays for that.
 
+using Plaga44.Interaction;
 using UnityEngine;
 
 public class StoneSpawner : MonoBehaviour

--- a/Assets/_Recovery/0 (1).unity
+++ b/Assets/_Recovery/0 (1).unity
@@ -2857,7 +2857,7 @@ MonoBehaviour:
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fc357ab418efed144aef741408dd8c65, type: 3}
   m_Name: 
-  m_EditorClassIdentifier: Assembly-CSharp::HandCollisionIgnore
+  m_EditorClassIdentifier: Assembly-CSharp::Plaga44.Core.HandCollisionIgnore
 --- !u!4 &973012411 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 416152, guid: 81d633455a8cc814e89ff68eb1deb8e7, type: 3}

--- a/Assets/_Recovery/0.unity
+++ b/Assets/_Recovery/0.unity
@@ -2764,7 +2764,7 @@ MonoBehaviour:
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fc357ab418efed144aef741408dd8c65, type: 3}
   m_Name: 
-  m_EditorClassIdentifier: Assembly-CSharp::HandCollisionIgnore
+  m_EditorClassIdentifier: Assembly-CSharp::Plaga44.Core.HandCollisionIgnore
 --- !u!4 &973012411 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 416152, guid: 81d633455a8cc814e89ff68eb1deb8e7, type: 3}

--- a/Assets/plaga4-BASE-Testing.unity
+++ b/Assets/plaga4-BASE-Testing.unity
@@ -2857,7 +2857,7 @@ MonoBehaviour:
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fc357ab418efed144aef741408dd8c65, type: 3}
   m_Name: 
-  m_EditorClassIdentifier: Assembly-CSharp::HandCollisionIgnore
+  m_EditorClassIdentifier: Assembly-CSharp::Plaga44.Core.HandCollisionIgnore
 --- !u!4 &973012411 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 416152, guid: 81d633455a8cc814e89ff68eb1deb8e7, type: 3}


### PR DESCRIPTION
## Summary
- Wraps `RuntimeGrabbable` in `Plaga44.Interaction`, `HandCollisionIgnore` and `SprintModifier` in `Plaga44.Core` namespace
- Prevents future ambiguous reference if a custom `CharacterController` class is ever added in a Plaga44 namespace
- Updates `using` directives in `StoneSpawner`, `HitDetector`, `TestEnvironmentSetup`
- Updates `m_EditorClassIdentifier` in all 6 scene files referencing `HandCollisionIgnore`

Closes #108

## Test plan
- [ ] Open Unity, verify no compilation errors
- [ ] Open `PLAGA44_Demo` scene -- verify `HandCollisionIgnore` component still attached to OVRPlayerController (not missing script)
- [ ] Play scene -- grab a stone, verify no collision push from CharacterController (RuntimeGrabbable collision ignore still works)
- [ ] Verify sprint (L3) and jump (B) still work (SprintModifier in namespace)
- [ ] Check hand colliders don't push player upward (HandCollisionIgnore still active)