### PR TITLE
feat: Introspection Menu -- look-down body status UI (#110)

### DIFF
--- a/Assets/Scripts/UI/IntrospectionMenu.cs
+++ b/Assets/Scripts/UI/IntrospectionMenu.cs
@@ -1,3 +1,13 @@
+// IntrospectionMenu.cs
+// PLAGA '44 -- Look-down body status UI.
+// Player looks down at their own body (head pitch < -45 deg for 1s)
+// and the Introspection Menu opens -- literally "looking inside yourself".
+//
+// Shows: character stats, equipment quick view, body condition, mental state.
+// World-space canvas at chest height, facing camera. Does NOT pause game.
+//
+// Requires: com.meta.xr.sdk.core (HAS_META_XR define)
+
 using UnityEngine;
 using UnityEngine.UI;
 
@@ -19,36 +29,42 @@ namespace Plaga44.UI
         public float openPitchThreshold = -45f;
 
         [Tooltip("Hold time in seconds before menu opens.")]
-        public float holdTime = 0.8f;
+        public float holdTime = 1.0f;
 
         [Tooltip("Head pitch angle to close menu (looking back up).")]
         public float closePitchThreshold = -20f;
 
         [Header("UI Position")]
-        [Tooltip("Vertical offset from camera (negative = below).")]
+        [Tooltip("Vertical offset from head (negative = below).")]
         public float chestOffsetY = -0.4f;
 
-        [Tooltip("Forward offset from camera.")]
+        [Tooltip("Forward offset from head.")]
         public float chestOffsetZ = 0.35f;
 
-        [Header("Haptics")]
-        [Tooltip("Vibration on menu open.")]
-        public float hapticFrequency = 0.3f;
-        public float hapticAmplitude = 0.4f;
-        public float hapticDuration = 0.15f;
+        [Header("Fade")]
+        [Tooltip("Time in seconds for the menu to fade in/out.")]
+        public float fadeDuration = 0.25f;
 
         // ── State ──
         private bool _isOpen;
         private float _lookDownTimer;
+        private float _fadeAlpha;
         private GameObject _canvasGO;
+        private CanvasGroup _canvasGroup;
         private Text _titleText;
         private Text _statsText;
+        private Text _equipText;
+        private Text _bodyText;
+        private Text _mindText;
         private Transform _camT;
-        private float _hapticTimer;
+
+#if HAS_META_XR
+        private OVRCameraRig _rig;
+#endif
 
         void Start()
         {
-            _camT = Camera.main?.transform;
+            FindCameraTransform();
             BuildCanvas();
             _canvasGO.SetActive(false);
         }
@@ -57,7 +73,7 @@ namespace Plaga44.UI
         {
             if (_camT == null)
             {
-                _camT = Camera.main?.transform;
+                FindCameraTransform();
                 if (_camT == null) return;
             }
 
@@ -65,20 +81,15 @@ namespace Plaga44.UI
             // Normalize: Unity gives 0-360, we want -180 to 180
             if (pitch > 180f) pitch -= 360f;
 
-            // Haptic cooldown
-            if (_hapticTimer > 0f) _hapticTimer -= Time.deltaTime;
-
             if (!_isOpen)
             {
-                // pitch is negative when looking down (after normalization above)
+                // pitch is negative when looking down (after normalization)
                 if (pitch < openPitchThreshold)
                 {
                     _lookDownTimer += Time.deltaTime;
                     if (_lookDownTimer >= holdTime)
                     {
                         Open();
-                        UpdatePosition();
-                        UpdateStats();
                     }
                 }
                 else
@@ -97,18 +108,43 @@ namespace Plaga44.UI
 
                 // Update position -- follow chest
                 UpdatePosition();
-                UpdateStats();
             }
+
+            // Handle fade
+            UpdateFade();
         }
+
+        // ── Camera discovery ──
+
+        void FindCameraTransform()
+        {
+#if HAS_META_XR
+            if (_rig == null)
+                _rig = FindFirstObjectByType<OVRCameraRig>();
+            if (_rig != null)
+            {
+                _camT = _rig.centerEyeAnchor;
+                return;
+            }
+#endif
+            // Fallback for editor testing without Meta XR
+            _camT = Camera.main?.transform;
+        }
+
+        // ── Open / Close ──
 
         void Open()
         {
             _isOpen = true;
             IsOpen = true;
+            _fadeAlpha = 0f;
             _canvasGO.SetActive(true);
             _lookDownTimer = 0f;
 
-            // Haptic feedback -- both controllers
+            UpdatePosition();
+            UpdateStats();
+
+            // Haptic feedback -- both controllers via HapticManager
             TriggerHaptics();
 
             Debug.Log("[INTROSPECTION] Menu opened -- player looks inside");
@@ -119,8 +155,14 @@ namespace Plaga44.UI
             _isOpen = false;
             IsOpen = false;
             _canvasGO.SetActive(false);
+            _fadeAlpha = 0f;
+            if (_canvasGroup != null)
+                _canvasGroup.alpha = 0f;
+
             Debug.Log("[INTROSPECTION] Menu closed");
         }
+
+        // ── Position & Fade ──
 
         void UpdatePosition()
         {
@@ -136,44 +178,82 @@ namespace Plaga44.UI
             _canvasGO.transform.position = pos;
 
             // Face camera but stay upright
-            Vector3 lookDir = (camPos - pos);
+            Vector3 lookDir = camPos - pos;
             lookDir.y = 0;
             if (lookDir.sqrMagnitude > 0.001f)
                 _canvasGO.transform.rotation = Quaternion.LookRotation(lookDir.normalized, Vector3.up);
         }
 
+        void UpdateFade()
+        {
+            if (!_isOpen) return;
+
+            if (_fadeAlpha < 1f)
+            {
+                _fadeAlpha += Time.deltaTime / Mathf.Max(fadeDuration, 0.01f);
+                _fadeAlpha = Mathf.Clamp01(_fadeAlpha);
+                if (_canvasGroup != null)
+                    _canvasGroup.alpha = _fadeAlpha;
+            }
+        }
+
+        // ── Stats display (placeholder -- wire to real game state later) ──
+
         void UpdateStats()
         {
-            // POC -- placeholder stats, replace with real game state later
             _statsText.text =
                 "<color=#88ff88>WYTRZYMALOSC</color>  |||||||...  72%\n" +
                 "<color=#ff8888>ZDROWIE</color>       |||||||||.  89%\n" +
-                "<color=#88ccff>STAMINA</color>       ||||||....  61%\n" +
-                "\n" +
+                "<color=#88ccff>STAMINA</color>       ||||||....  61%";
+
+            _equipText.text =
+                "<color=#ccaa55>EKWIPUNEK:</color>\n" +
+                "  L: [pusto]\n" +
+                "  R: [pusto]\n" +
+                "  Plecak: 2/8 slotow";
+
+            _bodyText.text =
                 "<color=#cccccc>CIALO:</color> brak ran\n" +
-                "<color=#cccccc>UMYSL:</color> stabilny\n" +
                 "<color=#cccccc>INFEKCJE:</color> brak\n" +
-                "\n" +
-                "<color=#666666>[ spojrz w gore aby zamknac ]</color>";
+                "<color=#cccccc>MUTACJE:</color> brak";
+
+            _mindText.text =
+                "<color=#bb88ff>UMYSL:</color> stabilny\n" +
+                "<color=#bb88ff>STRES:</color> niski\n" +
+                "<color=#bb88ff>MORALE:</color> neutralny";
         }
+
+        // ── Haptics ──
 
         void TriggerHaptics()
         {
 #if HAS_META_XR
-            OVRInput.SetControllerVibration(hapticFrequency, hapticAmplitude, OVRInput.Controller.LTouch);
-            OVRInput.SetControllerVibration(hapticFrequency, hapticAmplitude, OVRInput.Controller.RTouch);
-            _hapticTimer = hapticDuration;
-            Invoke(nameof(StopHaptics), hapticDuration);
+            // Use HapticManager singleton if available, otherwise fall back to direct API
+            var haptics = Plaga44.Feedback.HapticManager.Instance;
+            if (haptics != null)
+            {
+                haptics.PlayGrab(OVRInput.Controller.LTouch);
+                haptics.PlayGrab(OVRInput.Controller.RTouch);
+            }
+            else
+            {
+                // Fallback: gentle vibration on both controllers
+                OVRInput.SetControllerVibration(0.3f, 0.4f, OVRInput.Controller.LTouch);
+                OVRInput.SetControllerVibration(0.3f, 0.4f, OVRInput.Controller.RTouch);
+                Invoke(nameof(StopHaptics), 0.15f);
+            }
 #endif
         }
 
+#if HAS_META_XR
         void StopHaptics()
         {
-#if HAS_META_XR
             OVRInput.SetControllerVibration(0, 0, OVRInput.Controller.LTouch);
             OVRInput.SetControllerVibration(0, 0, OVRInput.Controller.RTouch);
-#endif
         }
+#endif
+
+        // ── Canvas construction ──
 
         void BuildCanvas()
         {
@@ -184,55 +264,98 @@ namespace Plaga44.UI
             canvas.renderMode = RenderMode.WorldSpace;
             canvas.sortingOrder = 998;
 
+            _canvasGroup = _canvasGO.AddComponent<CanvasGroup>();
+            _canvasGroup.alpha = 0f;
+            _canvasGroup.blocksRaycasts = false;
+            _canvasGroup.interactable = false;
+
             var rt = _canvasGO.GetComponent<RectTransform>();
-            rt.sizeDelta = new Vector2(400, 300);
+            rt.sizeDelta = new Vector2(420, 400);
             rt.localScale = Vector3.one * 0.001f; // 1px = 1mm
 
             // Semi-transparent dark background
+            BuildBackground(_canvasGO.transform);
+
+            // Title
+            _titleText = BuildTextElement(_canvasGO.transform, "Title",
+                "= INTROSPEKCJA =", 20,
+                new Color(0.9f, 0.85f, 0.7f), TextAnchor.UpperCenter,
+                new Vector2(0, 0.9f), Vector2.one,
+                "Arial");
+
+            // Stats section (top -- health/stamina)
+            _statsText = BuildTextElement(_canvasGO.transform, "Stats",
+                "", 15,
+                new Color(0.8f, 0.8f, 0.8f), TextAnchor.UpperLeft,
+                new Vector2(0.05f, 0.62f), new Vector2(0.95f, 0.88f),
+                "Courier New");
+
+            // Equipment section
+            _equipText = BuildTextElement(_canvasGO.transform, "Equipment",
+                "", 14,
+                new Color(0.8f, 0.75f, 0.6f), TextAnchor.UpperLeft,
+                new Vector2(0.05f, 0.4f), new Vector2(0.95f, 0.6f),
+                "Courier New");
+
+            // Body condition section
+            _bodyText = BuildTextElement(_canvasGO.transform, "Body",
+                "", 14,
+                new Color(0.7f, 0.7f, 0.7f), TextAnchor.UpperLeft,
+                new Vector2(0.05f, 0.2f), new Vector2(0.5f, 0.38f),
+                "Courier New");
+
+            // Mental state section
+            _mindText = BuildTextElement(_canvasGO.transform, "Mind",
+                "", 14,
+                new Color(0.75f, 0.7f, 0.85f), TextAnchor.UpperLeft,
+                new Vector2(0.5f, 0.2f), new Vector2(0.95f, 0.38f),
+                "Courier New");
+
+            // Footer hint
+            BuildTextElement(_canvasGO.transform, "Hint",
+                "<color=#666666>[ spojrz w gore aby zamknac ]</color>", 12,
+                new Color(0.4f, 0.4f, 0.4f), TextAnchor.LowerCenter,
+                new Vector2(0, 0.02f), new Vector2(1, 0.12f),
+                "Arial");
+        }
+
+        void BuildBackground(Transform parent)
+        {
             var bgGO = new GameObject("BG");
-            bgGO.transform.SetParent(_canvasGO.transform, false);
+            bgGO.transform.SetParent(parent, false);
             var bgImg = bgGO.AddComponent<Image>();
-            bgImg.color = new Color(0f, 0f, 0f, 0.7f);
+            bgImg.color = new Color(0.02f, 0.02f, 0.04f, 0.75f);
             bgImg.raycastTarget = false;
             var bgRT = bgGO.GetComponent<RectTransform>();
             bgRT.anchorMin = Vector2.zero;
             bgRT.anchorMax = Vector2.one;
             bgRT.offsetMin = Vector2.zero;
             bgRT.offsetMax = Vector2.zero;
+        }
 
-            // Title
-            var titleGO = new GameObject("Title");
-            titleGO.transform.SetParent(_canvasGO.transform, false);
-            _titleText = titleGO.AddComponent<Text>();
-            _titleText.font = Font.CreateDynamicFontFromOSFont("Arial", 20);
-            _titleText.fontSize = 20;
-            _titleText.color = new Color(0.9f, 0.9f, 0.9f);
-            _titleText.alignment = TextAnchor.UpperCenter;
-            _titleText.text = "= INTROSPEKCJA =";
-            _titleText.raycastTarget = false;
+        Text BuildTextElement(Transform parent, string name, string initialText,
+            int size, Color color, TextAnchor anchor,
+            Vector2 anchorMin, Vector2 anchorMax, string fontName)
+        {
+            var go = new GameObject(name);
+            go.transform.SetParent(parent, false);
 
-            var titleRT = titleGO.GetComponent<RectTransform>();
-            titleRT.anchorMin = new Vector2(0, 0.85f);
-            titleRT.anchorMax = new Vector2(1, 1f);
-            titleRT.offsetMin = Vector2.zero;
-            titleRT.offsetMax = Vector2.zero;
+            var text = go.AddComponent<Text>();
+            text.font = Font.CreateDynamicFontFromOSFont(fontName, size);
+            text.fontSize = size;
+            text.color = color;
+            text.alignment = anchor;
+            text.supportRichText = true;
+            text.raycastTarget = false;
+            text.text = initialText;
 
-            // Stats body
-            var statsGO = new GameObject("Stats");
-            statsGO.transform.SetParent(_canvasGO.transform, false);
-            _statsText = statsGO.AddComponent<Text>();
-            _statsText.font = Font.CreateDynamicFontFromOSFont("Courier New", 16);
-            _statsText.fontSize = 16;
-            _statsText.color = new Color(0.8f, 0.8f, 0.8f);
-            _statsText.alignment = TextAnchor.UpperLeft;
-            _statsText.supportRichText = true;
-            _statsText.raycastTarget = false;
+            var textRT = go.GetComponent<RectTransform>();
+            textRT.anchorMin = anchorMin;
+            textRT.anchorMax = anchorMax;
+            textRT.offsetMin = Vector2.zero;
+            textRT.offsetMax = Vector2.zero;
 
-            var statsRT = statsGO.GetComponent<RectTransform>();
-            statsRT.anchorMin = new Vector2(0.05f, 0.05f);
-            statsRT.anchorMax = new Vector2(0.95f, 0.82f);
-            statsRT.offsetMin = Vector2.zero;
-            statsRT.offsetMax = Vector2.zero;
+            return text;
         }
 
         /// <summary>Public read for other systems to check if introspection is active.</summary>


### PR DESCRIPTION
## Summary
- Improves the existing IntrospectionMenu POC to match the full spec from #110
- Uses `OVRCameraRig.centerEyeAnchor` instead of `Camera.main` for proper Quest head tracking
- Integrates `HapticManager` singleton for controller vibration feedback on menu open
- Adds all four UI sections: character stats, equipment quick view, body condition, mental state
- Adds `CanvasGroup` fade-in animation (0.25s) for visual polish
- Fixes hold time from 0.8s to 1.0s per issue spec

## Changes
- `Assets/Scripts/UI/IntrospectionMenu.cs` -- rewritten from POC to full implementation

## Test plan
- [ ] Build to Quest 3, deploy APK
- [ ] Look down (head pitch < -45 deg) and hold for 1 second -- menu should appear at chest height
- [ ] Verify haptic vibration on both controllers when menu opens
- [ ] Verify menu displays all sections: stats, equipment, body, mind
- [ ] Verify menu fades in smoothly (0.25s)
- [ ] Look back up (pitch > -20 deg) -- menu should close
- [ ] Verify menu does NOT pause the game (ambient sounds, NPCs still active)
- [ ] Verify `IntrospectionMenu.IsOpen` returns correct state (for other systems)
- [ ] Test in Editor without Meta XR SDK -- should fall back to Camera.main

Closes #110