### PR TITLE
fix: #147 SpecGloss combine -- cache dimensions before DestroyImmediate

### DIFF
--- a/Assets/Editor/AvatarImport.cs
+++ b/Assets/Editor/AvatarImport.cs
@@ -479,12 +479,17 @@ namespace Plaga44.Editor
                 var combined = MergeRgbAndRedToAlpha(spec, glossMatched);
                 File.WriteAllBytes(outPath, combined.EncodeToPNG());
 
+                // Cache dimensions BEFORE destroy -- reading Texture.width/height
+                // after DestroyImmediate throws UnityException (issue #147).
+                int w = combined.width;
+                int h = combined.height;
+
                 UnityEngine.Object.DestroyImmediate(spec);
                 if (glossMatched != gloss) UnityEngine.Object.DestroyImmediate(gloss);
                 UnityEngine.Object.DestroyImmediate(glossMatched);
                 UnityEngine.Object.DestroyImmediate(combined);
 
-                Debug.Log($"{LOG} SpecGloss combined: {combined.width}x{combined.height} -> {outPath}");
+                Debug.Log($"{LOG} SpecGloss combined: {w}x{h} -> {outPath}");
             }
             catch (Exception e)
             {


### PR DESCRIPTION
Closes #147

## Root cause
`AvatarImport.CombineSpecGloss` destroyed Texture then tried to read `.width/.height` in Debug.Log → UnityException → caught, logged as 'SpecGloss combine failed'.

## Fix
Cache w/h into int locals BEFORE DestroyImmediate.

## Test scenario
1. Delete `Assets/PLAGA44/Avatars/PINEA_YNG5/textures/PINEA_YNG5_SpecGloss.png`
2. CYBERNOMAD > Import > Rescan Avatars
3. ✅ Console: `SpecGloss combined: 4096x4096 -> ...` (was: 'combine failed')
4. Check PINEA material renders non-pink

## Verification
Batch run passed: `SpecGloss combined: 4096x4096 -> PINEA_YNG5_SpecGloss.png`

🤖 Generated with [Claude Code](https://claude.com/claude-code)