### PR TITLE
fix: #157 avatar switch works mid-flight (force gallery spawn on menu open)

### DIFF
--- a/Assets/Scripts/Core/AvatarGallery.cs
+++ b/Assets/Scripts/Core/AvatarGallery.cs
@@ -118,7 +118,20 @@ namespace Plaga44
         {
             if (_spawned || _instances == null || _instances.Length == 0) return;
             if (!IsPlayerGrounded()) return;
+            DoSpawn("auto (grounded)");
+        }
 
+        /// <summary>Force spawn now regardless of grounded state (issue #157).
+        /// Called by HamburgerMenu on open -- preview should be visible whenever menu is open,
+        /// even if player is mid-flight.</summary>
+        public void ForceSpawnNow()
+        {
+            if (_spawned || _instances == null || _instances.Length == 0) return;
+            DoSpawn("force (menu open)");
+        }
+
+        private void DoSpawn(string reason)
+        {
             ResolveOrigin(out Vector3 origin, out Vector3 rowRight);
             Vector3 dir = direction.sqrMagnitude > 0.0001f ? direction.normalized : rowRight;
             var rot = Quaternion.Euler(0f, yaw, 0f);
@@ -128,7 +141,7 @@ namespace Plaga44
 
             ApplyInitialLazyState();
             _spawned = true;
-            Debug.Log($"{LOG} Spawned {spawned}/{_instances.Length} avatars at {origin} (lazy={lazyDisplay}, active={_activeIndex}) [deferred until grounded]");
+            Debug.Log($"{LOG} Spawned {spawned}/{_instances.Length} avatars at {origin} (lazy={lazyDisplay}, active={_activeIndex}) [trigger={reason}]");
         }
 
         private static bool IsPlayerGrounded()

--- a/Assets/Scripts/UI/HamburgerMenu.cs
+++ b/Assets/Scripts/UI/HamburgerMenu.cs
@@ -191,6 +191,11 @@ namespace Plaga44.UI
             _level = MenuLevel.Top;
             _topIndex = 0;
             ShowLevel();
+
+            // Issue #157: force gallery spawn on menu open so preview is visible even mid-flight.
+            var gallery = Plaga44.AvatarGallery.Instance;
+            if (gallery != null) gallery.ForceSpawnNow();
+
             Debug.Log($"{LOG} OPEN");
         }
 


### PR DESCRIPTION
Closes #157. Gallery deferred spawn blocked mid-flight. Now ForceSpawnNow on menu open.