### PR TITLE
fix: #155 PINEA pink -- add _SPECULAR_SETUP keyword

### DIFF
--- a/Assets/Editor/AvatarImport.cs
+++ b/Assets/Editor/AvatarImport.cs
@@ -68,6 +68,9 @@ namespace Plaga44.Editor
         public const string KeywordNormalMap = "_NORMALMAP";
         public const string KeywordSpecGlossMap = "_SPECGLOSSMAP";
         public const string KeywordMetallicSpecGlossMap = "_METALLICSPECGLOSSMAP";
+        // Specular workflow routing -- URP/Lit requires this for spec color/map to render correctly.
+        // Without it shader falls back to metallic branch -> pink/broken look (issue #155).
+        public const string KeywordSpecularSetup = "_SPECULAR_SETUP";
 
         // Workflow: 0=Metallic, 1=Specular
         public const float WorkflowSpecular = 1f;
@@ -580,6 +583,9 @@ namespace Plaga44.Editor
             mat.SetFloat(UrpLit.BumpScale, 1f);
             mat.SetColor(UrpLit.BaseColor, Color.white);
             mat.SetColor(UrpLit.SpecColor, Color.white);
+            // Issue #155: URP/Lit needs _SPECULAR_SETUP to route to specular branch.
+            // Without it, shader uses metallic path and ignores _SpecColor/_SpecGlossMap -> pink/broken.
+            mat.EnableKeyword(UrpLit.KeywordSpecularSetup);
         }
 
         private static void BindTextures(Material mat, string tDiffuse, string tNormal, string tSpecGloss)

--- a/Assets/PLAGA44/Avatars/PINEA_YNG5/PINEA_YNG5_Mat.mat
+++ b/Assets/PLAGA44/Avatars/PINEA_YNG5/PINEA_YNG5_Mat.mat
@@ -28,6 +28,7 @@ Material:
   - _METALLICSPECGLOSSMAP
   - _NORMALMAP
   - _SPECGLOSSMAP
+  - _SPECULAR_SETUP
   m_InvalidKeywords: []
   m_LightmapFlags: 4
   m_EnableInstancingVariants: 0


### PR DESCRIPTION
Closes #155. URP/Lit Specular workflow requires _SPECULAR_SETUP keyword. Added to AvatarImport + patched existing material.